### PR TITLE
Wiki audit

### DIFF
--- a/wiki/dropping-accelerate-support.md
+++ b/wiki/dropping-accelerate-support.md
@@ -1,0 +1,119 @@
+**UPDATE: the plan was implemented in [gh-8670](https://github.com/scipy/scipy/pull/8670) which is merged and appeared in 1.2.0 (december 2018)**
+
+Motivation
+----------
+
+SciPy relies extensively on LAPACK and BLAS libraries and for that reason the SciPy building process involves linking to these Fortran sources. 
+While building NumPy/SciPy is still a quite problematic area in Windows systems for the average users, the situation for Linux and OSX systems is quite the opposite if the documentation is followed. In the building procedure  for OSX systems, many users rely on the readily-provided Accelerate Framework by Apple, which among other tools, includes LAPACK and BLAS libraries.
+
+Recently, this convenience that many still enjoy for OSX systems, has become a bottleneck for the SciPy development team for various reasons, mainly for the following: 
+
+- Apple support for Accelerate (as for other Apple code) is opaque.  Bug reports, and replies to reports, are [private to the Apple engineers](https://developer.apple.com/bug-reporting/).  As a result we find ourselves having to patch around bugs that are due to Accelerate (e.g. [gh-7131](https://github.com/scipy/scipy/pull/7131), [#7050](https://github.com/scipy/scipy/issues/7050)). Because of the opaque support process, the Accelerate framework bugs are difficult to discover/blame.
+- The APIs implemented by the LAPACK and BLAS libraries are outdated by about a decade.  Currently the LAPACK version is 3.7.1 vs. Accelerate's 3.2.1 from 2009.  This is an issue because Scipy cannot make use of recently introduced functionality in LAPACK (e.g. [gh-6831](https://github.com/scipy/scipy/pull/6831), [#7500](https://github.com/scipy/scipy/issues/7500)). Internal LAPACK deprecations create extra maintenance efforts across different versions (e.g., [#5266](https://github.com/scipy/scipy/issues/5266)).
+- The new features to-be-added to SciPy are blocked by the absence of routines introduced in later versions LAPACK/BLAS libraries.
+- Known issues/deprecations of LAPACK/BLAS need to be addressed at the SciPy level since later fixes can't be incorporated which adds complication for build processes.
+
+We have thus far defaulted to maintaining Accelerate support because:
+
+- Accelerate is present on every Mac, meaning that we do not have to install other libraries in order to build Numpy.
+- It appears to be optimized for the hardware it is running on.
+- At least by reputation, Accelerate has top-of-range or competitive performance.
+- [Some users](http://vtk.1045678.n5.nabble.com/VTK-and-Python-on-OS-X-El-Capitan-tp5734265p5734280.html) want Accelerate support specifically, usually because they believe it gives the best performance.
+
+We might be getting to the point where the cons outweigh the pros.  We are therefore considering alternative build options for OSX. This document is a summary of various discussions, mainly under [gh-6051](https://github.com/scipy/scipy/pull/6051).  
+
+For any alternative building process, Accelerate (or parts of) needs to be overshadowed (See [gh-2620](https://github.com/scipy/scipy/pull/7131) for a similar attempt which was cancelled). 
+
+## Options
+
+See also discussion at [OpenBLAS for OSX numpy thread](https://mail.python.org/pipermail/numpy-discussion/2016-June/075681.html) continued [here](https://mail.python.org/pipermail/numpy-discussion/2016-July/075700.html).
+
+### Keep supporting Accelerate as we do now
+
+**Pros**: least effort, building/installing SciPy on OS X is easy.
+
+**Cons**: cannot make use of recently introduced functionality in LAPACK (e.g. [gh-6831](https://github.com/scipy/scipy/pull/6831)) or fix bugs that are due to Accelerate (e.g. [gh-7131](https://github.com/scipy/scipy/pull/7131), [#7050](https://github.com/scipy/scipy/issues/7500)). Internal LAPACK deprecations create extra maintenance efforts across different versions (e.g., [#5266](https://github.com/scipy/scipy/issues/5266))
+
+### Drop Accelerate support completely
+
+**Pros**: can move to LAPACK x.y.z, can remove Accelerate patching in ``scipy._build_utils``
+
+**Cons**: some people want to use Accelerate for performance reasons (see above). We force users to install another BLAS/LAPACK which is not easy right now. This could be addressed by shipping OpenBLAS with the Scipy wheel, or by packaging OpenBLAS as a wheel.  Packaging OpenBLAS as a wheel is a significant amount of work – we (@njsmith) know how to do it and have implemented the nasty binary rewriting stuff that's required, but work is still needed to set up build scripts etc. But in any case we don't need to decide this now, because we already have the infrastructure to ship OpenBLAS inside the wheel, just like we do on Linux.
+
+Shipping a Numpy / OpenBLAS wheel is relatively trivial, using the existing [multibuild](https://github.com/matthew-brett/multibuild) / [delocate](https://github.com/matthew-brett/delocate) machinery - see [this PR](https://github.com/MacPython/numpy-wheels/pull/1) for the changes required.  The Delocate program copies the OpenBLAS library into the Numpy wheel.
+
+### Keep using Accelerate BLAS but shadow LAPACK
+
+The actual discussion is difficult to summarize and needs to be read through in [gh-6051](https://github.com/scipy/scipy/pull/6051). A brief recollection of the ideas proposed
+- Using ``vecLibFort``, see https://github.com/scipy/scipy/pull/6051#issuecomment-225431271
+- Just bundling missing + broken routines: https://github.com/scipy/scipy/pull/6051#issuecomment-225431600
+
+and other possible options. 
+
+**Pros**: Still utilize Accelerate for build convenience selectively.
+
+**Cons**: Issues such as Integer overflow ([gh-7131](https://github.com/scipy/scipy/pull/7131)) is even present in fundamental BLAS functions like `*GEMM`. Even if we build LAPACK on top of Accelerate's CBLAS, it will still possibly be unstable and do not shield SciPy from further bugs in Accelerate.
+
+## Other considerations
+
+### Which minimum LAPACK version to support?
+
+We've always used the guideline that the BLAS/LAPACK versions shipped with the
+most popular Linux distributions should be supported until the distribution
+becomes end-of-life.  The LAPACK versions shipped with the oldest not yet
+end-of-life distributions are:
+
+- Debian 7 (Wheezy): 3.4.1
+- Ubuntu 14.04 LTS: 3.5.0
+- Fedora 25: 3.6.1
+- CentOS 7: 3.4.2
+
+There are three BLAS/LAPACK libraries that we support on all platforms:
+
+- Intel MKL 11.1.4 (latest supported MKL version for Python 2.7 on Windows, see https://github.com/scipy/scipy/pull/6051#issuecomment-329542591): 3.4.0 
+- Intel MKL 11.3: 3.6
+- OpenBLAS 0.2.20: 3.7.0
+- ATLAS 3.10.3: 3.6.1
+
+Supporting those old Linux distributions can be important, because users often
+have to work on clusters running such distributions.  They can build the latest
+SciPy version, and we'd like them to be able to do that without also having to
+build a LAPACK library by themselves (that tends to be harder).
+
+However, there's a couple of arguments we may want to not support Linux
+distributions till their end-of-life:
+
+1. It means we'll always be many years behind the latest LAPACK. E.g. CentOS 7
+   is supported until 2020, and has LAPACK 3.4.1 from 2012.
+2. On OS X and Windows we will require users to install a LAPACK library
+   themselves.  If they can deal with it, then Linux users can too.
+3. OpenBLAS has become stable enough for general use, and is *much* easier to
+   compile than ATLAS.
+4. We're going to have to provide OpenBLAS wheels for OS X users.  If we do
+   that, then we can also provide ``manylinux`` wheels.
+
+Those seem like compelling arguments for a more aggressive update strategy, and
+require at least 3.5.0 or 3.6.0.  Another downside is that we will be making a
+lot of install instructions out in the wild obsolete (they will all have
+something like ``sudo apt-get install libatlas-dev``).
+
+Another consideration could be our continuous integration needs.  TravisCI runs
+Ubuntu LTS, so provides 3.5.0.  It's a minor issue compared with all the other
+considerations though - easy enough to build 3.6.0 once and download it (or
+grab it from the cache) for each CI run.
+
+However, the most important factor seems to be MKL. MKL needs to be supported for all Python versions we support, because it's the default LAPACK used on Windows with Anaconda, Canopy, etc. Because MKL + Python 2.7 (needs MSVC 2008) only supports LAPACK 3.4.0, that is the highest we can bump the minimum supported version to.
+
+### ABI issues with shadowing
+
+MKL also uses a g77 ABI, see https://github.com/scipy/scipy/pull/6051#issuecomment-225431914 
+
+### NumPy-related Impact
+
+The scenario in which SciPy drops support for Accelerate but NumPy stays with it, has not been discussed yet.
+
+There is also some discomfort raised in the NumPy mailing list about linking to Accelerate. A blocking issue example has been provided about multiprocessing which can be read [in this mailing list thread (with a quote from Apple)](https://mail.scipy.org/pipermail/numpy-discussion/2012-August/063589.html). This problem was due to a bug in multiprocessing and is fixed in Python 3.4 and later; Accelerate was POSIX compliant but multiprocessing was not.
+
+## Rejected alternatives
+
+Dropping all of LAPACK into SciPy (see https://github.com/scipy/scipy/pull/6051#issuecomment-266380190).

--- a/wiki/gsoc/2015-project-ideas.md
+++ b/wiki/gsoc/2015-project-ideas.md
@@ -1,0 +1,219 @@
+## Introduction
+
+This is the GSoC'15 ideas page for both SciPy and NumPy.  The SciPy library is one of the core packages that make up the SciPy stack. It provides many user-friendly and efficient numerical routines such as routines for numerical integration and optimization.  NumPy is the fundamental package for scientific computing with Python. It contains a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran code,linear algebra, Fourier transform, and random number capabilities.
+
+This page lists a number of ideas for Google Summer of Code projects for both Scipy and Numpy, plus gives some pointers for potential GSoC students on how to get started with contributing and putting together their application.  It's a joint page because the Numpy and Scipy projects are quite closely related; there is a large overlap in both user community and in developers.
+
+### Guidelines & requirements
+
+SciPy and NumPy participate in GSoC 2015 under the [umbrella of Python Software Foundation](https://wiki.python.org/moin/SummerOfCode/2015).
+
+PSF student guidelines: http://wiki.python.org/moin/SummerOfCode/Expectations
+
+[Advice on writing a proposal](http://turnbull.sk.tsukuba.ac.jp/Blog/SPAM.txt#how-to-spam-in-detail) (written with the Mailman project in mind, but generally applicable)
+
+The application template for 2015 doesn't yet exist, but it's expected to be very similar to that of 2014: [Application template for 2014](https://wiki.python.org/moin/SummerOfCode/ApplicationTemplate2014)
+
+We expect from students that they're at least comfortable with Python (intermediate level). Some projects may also require Cython or C skills. Knowing how to use Git is also important; this can be learned before the official start of GSoC if needed though.
+
+### Advice
+
+Potential candidates should to take a look at [the guidelines on how to contribute to Scipy](https://github.com/scipy/scipy/blob/master/HACKING.rst.txt). Making a small enhancement/bugfix/documentation fix/etc (does not need to be related to your proposal) to Scipy or Numpy before applying for the GSoC is a requirement from the PSF; it can help you get some idea how things would work during the GSoC. 
+
+Start on your proposal early, post a draft to the mailing list and iterate based on the feedback you receive. This will not only improve the quality of your proposal, but also help you find a suitable mentor.
+
+
+## SciPy Project ideas
+
+### ``scipy.stats`` improvements
+
+``scipy.stats`` is one of the largest and most heavily used modules in Scipy. There has been an ongoing effort to improve the quality of this module, and it is now approaching what is needed for "Scipy 1.0". There are however still a few important improvements to be made and maintenance issues to be addressed:
+  1. all the hypothesis tests should get a keyword ``'alternative'`` to give the user a choice of hypotheses to use (see stats.kstest for an example)
+  2. documentation and test coverage of a number of functions is lacking (see Statistics Cleanup in Related reading below).
+  3. a few functions may need to be deprecated (also part of Statistics Cleanup)
+  4. we want to convert functions that return multiple parameters to return NamedTuples (see issue 4192 linked below)
+  5. functions for working with missing data (``scipy.stats.mstats``) need to be made consistent with their ``scipy.stats`` counterparts
+
+- Required knowledge: Python, preferably some knowledge of statistics
+- Difficulty level: easy
+- Potential mentors: Ralf Gommers
+- Related reading: https://github.com/scipy/scipy/milestones/StatisticsCleanup, https://github.com/scipy/scipy/issues/4192
+
+
+### Discrete Wavelet Transforms
+
+Solid support for discrete wavelet transforms is one of the main missing features of scipy.signal, and perhaps even of Scipy as a whole.  Adding this support would start by integrating https://github.com/rgommers/pywt - includes integrating it into the Scipy build system, fixing some remaining inconsistencies in the API and adding documentation to the Scipy Reference guide - then adding some new features. Feature ideas:
+  1. 1-D and 2-D inverse SWT (have been requested several times on the PyWavelets list and issue tracker).
+  2. signal denoising (SureShrink & co, for scipy.signal)
+  3. image compression/denoising/... algorithms (for scikit-image)
+
+- Required knowledge: Python, Cython. Knowledge of wavelet transforms and programming in C will also be useful.
+- Difficulty level: easy/intermediate
+- Potential mentors: Ralf Gommers, Stefan van der Walt
+- Related reading: https://github.com/scipy/scipy/wiki/GSoC-2014-:-Discrete-Wavelet-Transform-proposal-draft
+
+
+### Porting scipy.ndimage to Cython
+
+This would be a joint project between scikit-image and Scipy that would provide a major improvement in maintainability and extensibility of ``ndimage``. Please see the [scikit-image GSoC page](https://github.com/scikit-image/scikit-image/wiki/GSoC-2015) for details.
+
+
+### Improve interpolation capabilities
+
+Implement routines for evaluating, manipulating, and fitting B-splines and their tensor products to data. Currently, Scipy relies largely on the FITPACK Fortran library for its B-spline functionality. Using this library is not the best option for Python-based software, and reimplementing and extending the functionality set would bring additional flexibility. A start in this direction is in [gh-3174](https://github.com/scipy/scipy/pull/3174) --- however, the task is likely to be large enough to keep several people occupied.
+
+Implement cubic regular grid interpolation schemes that does not need additional memory. Nearest-neighbor and linear schemes are implemented here: [gh-3323](https://github.com/scipy/scipy/pull/3323). ``scipy.ndimage`` contains similar schemes, but is restricted to uniformly spaced grids.
+
+(Course material on B-splines: http://www.uio.no/studier/emner/matnat/ifi/INF-MAT5340/v05/undervisningsmateriale/ )
+
+- Required knowledge: Python, Cython, spline math
+- Difficulty level: intermediate
+- Potential mentors: Evgeni Burovski
+
+### Optimization
+
+Implement and test Levenberg-Marquardt / trust region nonlinear least squares algorithm that supports additional features such as sparse Jacobian matrices and inequality constraints.
+(This project involves a literature search for determining a suitable algorithmic approach.)
+
+- Required knowledge: Python
+- Difficulty level: intermediate
+- Potential mentors: Pauli Virtanen
+- Related reading: https://github.com/scipy/scipy/pull/90
+
+
+### Implement scipy.diff (numerical differentiation)
+
+Numerical derivative calculation methods are a set of core scientific numerical tools that are currently missing in SciPy. There has been discussion (and general agreement) on creating a new ``scipy.diff`` sub-package starting with the ``numdifftools`` code and some code in ``statsmodels`` (see https://github.com/scipy/scipy/issues/2035).
+The project would be roughly (1) familiarise yourself with the code and methods in `numdifftools` and `statsmodels` (and maybe look at equivalent packages in other languages), (2) define the API, specifically broadcasting behavior, to make sure it covers all major use cases efficiently, (3) implement `scipy.diff`, including tests and docs.
+Optionally, if there's time left, these methods could be used to compute Hesse and covariance matrices and fit parameter error in `scipy.optimize` or other packages like `statsmodels` or `lmfit` if they are considered out of scope for `scipy.optimize` for some reason.
+- Required knowledge: Python, numerical derivatives
+- Difficulty level: intermediate
+- Potential mentors: Christoph Deil
+- Related reading: https://github.com/scipy/scipy/issues/2035
+
+
+### Your own idea
+
+The above projects are just suggestions --- it is also very good to suggest a project idea of your own if you have something in mind that you want to do. Ask people on the [mailing list](http://scipy.org/scipylib/mailing-lists.html) for suggestions in this case.
+
+
+### And more...
+
+A miscellaneous set of additional ideas can be found on the tentative [Scipy 1.0 roadmap](https://github.com/rgommers/scipy/blob/roadmap/doc/ROADMAP.rst.txt). You can help us reach this goal!
+
+
+## NumPy Project ideas
+
+
+### Airspeed Velocity (ASV) compatible benchmarks
+
+Work is currently being done to add ASV compatible benchmarks to Scipy, see [4501](https://github.com/scipy/scipy/pull/4501), [4534](https://github.com/scipy/scipy/pull/4534), [4541](https://github.com/scipy/scipy/pull/4541). A similar set of benchmarks for Numpy would be useful. A selection of benchmarks using vbench are currently maintained by [yarioptic](http://yarikoptic.github.io/numpy-vbench/).
+
+- Required knowledge: Python, Numpy, ASV would be plus.
+- Difficulty level: intermediate
+- Potential mentors: Charles Harris
+
+
+### Vector math library integration
+
+Some operations like powers, sin, cos etc are relatively slow in numpy
+depending on the c library used. There are now a few free libraries
+available that make use of modern hardware to speed these operations up,
+e.g. sleef and yeppp. This project is to evaluate these libraries, and integrate one or more of them into numpy, providing a nice speedup to many operations.
+
+- Required knowledge: C
+- Difficulty level: intermediate
+- Potential mentors: Julian Taylor
+
+
+### Porting parts of Numpy from C to Cython
+
+The numpy core contains tons of complicated C code implementing
+elaborate operations like indexing, casting, ufunc dispatch, etc. It
+would be really nice if we could use Cython to write some of these
+things -- and especially, this would make it a lot nicer to add *new* features. However, there is a practical problem: Cython assumes that
+each .pyx file generates a single compiled module with its own
+Cython-defined API. Numpy, however, contains a large number of .c
+files which are all compiled together into a single module, with its
+own home-brewed system for defining the public API. And we can't
+rewrite the whole thing. So for this to be viable, we would need some
+way to compile a bunch of .c *and .pyx* files together into a single
+module, and allow the .c and .pyx files to call each other. This might
+involve changes to Cython, some sort of clever post-processing or glue
+code to get existing cython-generated source code to play nicely with
+the rest of Numpy, or something else.
+
+So this project would have the following goals, depending on how
+practical this turns out to be: (1) produce a hacky proof-of-concept
+system for doing the above, (2) turn the hacky proof-of-concept into
+something actually viable for use in real life (possibly this would
+require getting changes upstream into Cython, etc.), (3) use this
+system to actually port some interesting numpy code into cython.
+
+- Required knowledge: Python, Cython, C
+- Difficulty level: hard
+- Potential mentors: Nathaniel Smith
+
+### Pythonic dtypes
+
+Numpy has two fundamental types: `ndarray`, which implements a strided multi-dimensional array of binary data, and `dtype`, which tells `ndarray` how to interpret that binary data as something actually useful (e.g., a floating point number). This project involves making a fundamental improvement in one of these fundamental pieces.
+
+Numpy's current dtype system is kludgy. It basically defines its own class
+system, in parallel to Python's, and unsurprisingly, this new class
+system is not as good. In particular, it has limitations around the
+storage of instance-specific data which rule out a large variety of
+interesting user-defined dtypes, and causes us to need some truly
+nasty hacks to support the built-in dtypes we do have. And it makes
+defining a new dtype much more complicated than defining a new Python
+class.
+
+This project would be to implement a new dtype system for numpy, in
+which np.dtype becomes a near-empty base class, different dtypes
+(e.g., float64, float32) are simply different subclasses of np.dtype,
+and dtype objects are simply instances of these classes. Further
+enhancements would be to make it possible to define new dtypes in pure
+Python by subclassing ``np.dtype`` and implementing special methods for
+the various dtype operations, and to make it possible for ufunc loops
+to see the dtype objects.
+
+This project would provide the key enabling piece for a wide variety
+of interesting new features: missing value support, better handling of
+strings and categorical data, unit handling, automatic
+differentiation, and probably a bunch more I'm forgetting right now.
+
+- Required knowledge: Python, C
+- Difficulty level: hard
+- Potential mentors: Nathaniel Smith
+
+### Improve Numpy datetime functionality
+
+Handling of time zones in numpy.datetime is currently problematic.  A write-up and several ideas to improve it are summarized at http://article.gmane.org/gmane.comp.python.numeric.general/53805. This project would start by writing a NEP (Numpy Enhancement Proposal) on which alternative to choose, and then implement the NEP. Requires solid C skills.
+
+- Required knowledge: Python, C
+- Difficulty level: hard
+
+
+## Student applications for 2015 to Scipy and Numpy
+- Maniteja Nandana: *Scipy: proposal to add scipy.diff package* [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/inspiremaniteja/5629499534213120),   [public draft proposal](https://github.com/maniteja123/GSoC/wiki/Proposal%3A-add-finite-difference-numerical-derivatives-as-%60%60scipy.diff%60%60)
+
+- Abraham de Jesus Escalante Avalos: *Scipy: scipy.stats improvements* [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/abraham_escalante/5629499534213120),   [public draft proposal](https://onedrive.live.com/view.aspx?resid=E5548AD35687C4B2!494&ithint=file%2cpdf&app=WordPdf&authkey=!AESFhKX64QBOPd8)
+
+- Nikolay Mayorov: *Improve nonlinear least squares minimization functionality in SciPy* [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/nmayorov/5629499534213120),   [public draft proposal](https://stackedit.io/viewer#!provider=gist&gistId=d806ad6048c7e3df4797&filename=GSOC_proposal.md)
+
+- Anastasiia Tsyplia: *SciPy: FITPACK alternative with Python/Cython* [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/vermelha/5629499534213120),   [public draft proposal](https://drive.google.com/open?id=0BzveGSDwNVtBVDZiUlgybGNpcFk&authuser=0)
+
+- Anastasiia Tsyplia: *SciPy: Multivariate tensor product spline* [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/vermelha/5707702298738688),   [public draft proposal](https://drive.google.com/open?id=0BzveGSDwNVtBaW02VktrZndJdnc&authuser=0)
+
+- Tsutsumi Fukumu: *SciPy: Implement scipy.diff (numerical differentiation)*   [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/levelfour/5629499534213120),   [public draft proposal](http://markdownshare.com/view/fdd1aa36-3399-4498-a8a9-57a956bafb9d)
+
+- Oguzhan Unlu: *Numpy - Vector math library integration*  [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/blacksimit/5741031244955648),   [public draft proposal](https://gist.github.com/oguzhanunlu/1f8bf3ffc6ac5c420dd1)
+
+- Marcos Chavez: *Numpy - Porting core functions of Numpy from C++ to Python/Cython* [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/marcospc6/5629499534213120),   [public draft proposal](https://github.com/marcospc6/GSoC-Proposal/blob/master/gsocproposal.md)
+
+- Shubhankar: *Vector Math Library Integration in Numpy* [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/mshubhankar/5629499534213120),   [public draft proposal](https://github.com/mshubhankar/gsoc2015/blob/master/Proposal.md)
+
+
+And one proposal to Scikit-image which is intended to be a joint effort between the Scikit-image and Scipy teams:
+
+- Aman Singh: *Scikit-Image: rewriting scipy.ndimage to cython* [Melange proposal](http://www.google-melange.com/gsoc/proposal/review/org/google/gsoc2015/bewithaman/5629499534213120),   [public draft proposal](https://docs.google.com/document/d/11RTVaDQDu38mrEv3WPdguxprJ-ha5kGnx2LhpEUFE8g/edit)
+

--- a/wiki/gsoc/2016-project-ideas.md
+++ b/wiki/gsoc/2016-project-ideas.md
@@ -1,0 +1,201 @@
+## Introduction
+
+This is the GSoC'16 ideas page for both SciPy and NumPy.  The SciPy library is one of the core packages that make up the SciPy stack. It provides many user-friendly and efficient numerical routines such as routines for numerical integration and optimization.  NumPy is the fundamental package for scientific computing with Python. It contains a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran code,linear algebra, Fourier transform, and random number capabilities.
+
+This page lists a number of ideas for Google Summer of Code projects for both Scipy and Numpy, plus gives some pointers for potential GSoC students on how to get started with contributing and putting together their application.  It's a joint page because the Numpy and Scipy projects are quite closely related; there is a large overlap in both user community and in developers.
+
+### Guidelines & requirements
+
+SciPy and NumPy participate in GSoC 2016 under the [umbrella of Python Software Foundation](https://wiki.python.org/moin/SummerOfCode/2016).
+
+PSF student guidelines: http://wiki.python.org/moin/SummerOfCode/Expectations
+
+[Advice on writing a proposal](http://turnbull.sk.tsukuba.ac.jp/Blog/SPAM.txt#how-to-spam-in-detail) (written with the Mailman project in mind, but generally applicable)
+
+The application template for 2016 doesn't yet exist, but it's expected to be very similar to that of 2014: [Application template for 2014](https://wiki.python.org/moin/SummerOfCode/ApplicationTemplate2014)
+
+We expect from students that they're at least comfortable with Python (intermediate level). Some projects may also require Cython or C skills. Knowing how to use Git is also important; this can be learned before the official start of GSoC if needed though.
+
+### Advice
+
+Potential candidates should to take a look at [the guidelines on how to contribute to Scipy](https://github.com/scipy/scipy/blob/master/HACKING.rst.txt). Making a small enhancement/bugfix/documentation fix/etc (does not need to be related to your proposal) to Scipy or Numpy before applying for the GSoC is a requirement from the PSF; it can help you get some idea how things would work during the GSoC. 
+
+Start on your proposal early, post a draft to the mailing list and iterate based on the feedback you receive. This will not only improve the quality of your proposal, but also help you find a suitable mentor.
+
+
+## SciPy Project ideas
+
+
+### Porting scipy.ndimage to Cython
+
+This would be a joint project between scikit-image and Scipy that would provide a major improvement in maintainability and extensibility of ``ndimage``. Please see the [scikit-image GSoC page](https://github.com/scikit-image/scikit-image/wiki/GSoC-2015) for details.
+
+- Required knowledge: Python, Cython, C
+- Difficulty level: intermediate
+- Potential mentors: 
+
+
+### Implement scipy.diff (numerical differentiation)
+
+Numerical derivative calculation methods are a set of core scientific numerical tools that are currently missing in SciPy. There has been discussion (and general agreement) on creating a new ``scipy.diff`` sub-package starting with the ``numdifftools`` code and some code in ``statsmodels`` (see https://github.com/scipy/scipy/issues/2035).
+The project would be roughly (1) familiarise yourself with the code and methods in `numdifftools` and `statsmodels` (and maybe look at equivalent packages in other languages), (2) define the API, specifically broadcasting behavior, to make sure it covers all major use cases efficiently, (3) implement `scipy.diff`, including tests and docs.
+Optionally, if there's time left, these methods could be used to compute Hesse and covariance matrices and fit parameter error in `scipy.optimize` or other packages like `statsmodels` or `lmfit` if they are considered out of scope for `scipy.optimize` for some reason.
+
+- Required knowledge: Python, numerical derivatives
+- Difficulty level: intermediate
+- Potential mentors: 
+- Related reading: https://github.com/scipy/scipy/issues/2035
+
+
+### Improve the parabolic cylinder functions
+
+The parabolic cylinder functions are a family of special functions that have applications in PDEs and quadratures. SciPy has implementations of these functions (`special.pbdv`, `special.pbvv`, and `special.pbwa`), but significantly improved implementations are possible thanks to research advances in the last several years. The project would be to study a sequence of papers by Gil, Segura, and Temme and implement their algorithm for the parabolic cylinder functions from scratch in Cython.
+
+- Required knowledge: Cython, enough comfort with mathematics to learn about asymptotics and quadrature
+- Difficulty level: intermediate
+- Potential mentors: Josh Wilson
+- Related reading: https://dl.acm.org/citation.cfm?doid=1132973.1132978 (Only look at the paper! The license for the source code is incompatible with SciPy.)
+
+### Your own idea
+
+The above projects are just suggestions --- it is also very good to suggest a project idea of your own if you have something in mind that you want to do. Ask people on the [mailing list](http://scipy.org/scipylib/mailing-lists.html) for suggestions in this case.
+
+
+### And more...
+
+A miscellaneous set of additional ideas can be found on the tentative [Scipy 1.0 roadmap](https://github.com/rgommers/scipy/blob/roadmap/doc/ROADMAP.rst.txt). You can help us reach this goal!
+
+
+## NumPy Project ideas
+
+
+### Vector math library integration
+
+Some operations like powers, sin, cos etc are relatively slow in numpy
+depending on the c library used. There are now a few free libraries
+available that make use of modern hardware to speed these operations up,
+e.g. sleef and yeppp. This project is to evaluate these libraries, and integrate one or more of them into numpy, providing a nice speedup to many operations.
+
+- Required knowledge: C
+- Difficulty level: intermediate
+- Potential mentors:
+
+
+### Porting parts of Numpy from C to Cython
+
+The numpy core contains tons of complicated C code implementing
+elaborate operations like indexing, casting, ufunc dispatch, etc. It
+would be really nice if we could use Cython to write some of these
+things -- and especially, this would make it a lot nicer to add *new* features. However, there is a practical problem: Cython assumes that
+each .pyx file generates a single compiled module with its own
+Cython-defined API. Numpy, however, contains a large number of .c
+files which are all compiled together into a single module, with its
+own home-brewed system for defining the public API. And we can't
+rewrite the whole thing. So for this to be viable, we would need some
+way to compile a bunch of .c *and .pyx* files together into a single
+module, and allow the .c and .pyx files to call each other. This might
+involve changes to Cython, some sort of clever post-processing or glue
+code to get existing cython-generated source code to play nicely with
+the rest of Numpy, or something else.
+
+So this project would have the following goals, depending on how
+practical this turns out to be: (1) produce a hacky proof-of-concept
+system for doing the above, (2) turn the hacky proof-of-concept into
+something actually viable for use in real life (possibly this would
+require getting changes upstream into Cython, etc.), (3) use this
+system to actually port some interesting numpy code into cython.
+
+- Required knowledge: Python, Cython, C
+- Difficulty level: hard
+- Potential mentors:
+
+### Pythonic dtypes
+
+Numpy has two fundamental types: `ndarray`, which implements a strided multi-dimensional array of binary data, and `dtype`, which tells `ndarray` how to interpret that binary data as something actually useful (e.g., a floating point number). This project involves making a fundamental improvement in one of these fundamental pieces.
+
+Numpy's current dtype system is kludgy. It basically defines its own class
+system, in parallel to Python's, and unsurprisingly, this new class
+system is not as good. In particular, it has limitations around the
+storage of instance-specific data which rule out a large variety of
+interesting user-defined dtypes, and causes us to need some truly
+nasty hacks to support the built-in dtypes we do have. And it makes
+defining a new dtype much more complicated than defining a new Python
+class.
+
+This project would be to implement a new dtype system for numpy, in
+which np.dtype becomes a near-empty base class, different dtypes
+(e.g., float64, float32) are simply different subclasses of np.dtype,
+and dtype objects are simply instances of these classes. Further
+enhancements would be to make it possible to define new dtypes in pure
+Python by subclassing ``np.dtype`` and implementing special methods for
+the various dtype operations, and to make it possible for ufunc loops
+to see the dtype objects.
+
+This project would provide the key enabling piece for a wide variety
+of interesting new features: missing value support, better handling of
+strings and categorical data, unit handling, automatic
+differentiation, and probably a bunch more I'm forgetting right now.
+
+- Required knowledge: Python, C
+- Difficulty level: hard
+- Potential mentors: 
+
+### Improved duck typing support for N-dimensional arrays
+
+NumPy provides a powerful N-dimensional array object, but it isn't
+the only N-dimensional array in Python. There are many variants of
+NumPy arrays that it would be nice to work with using a similar API.
+Examples include:
+
+- [Sparse matrices in SciPy](http://docs.scipy.org/doc/scipy/reference/sparse.html)
+- NumPy's [MaskedArray](http://docs.scipy.org/doc/numpy/reference/maskedarray.html)
+- Labeled arrays in [xarray](http://xarray.pydata.org) and [pandas](http://pandas.pydata.org)
+- Alternative array backends such as [dask.array](http://dask.pydata.org/en/latest/array.html) and [Bolt](http://bolt-project.org/).
+- [DyND](http://libdynd.org/)'s N-dimensional array
+- Unit implementations such as [pint](https://pint.readthedocs.org) and [astropy.units](http://docs.astropy.org/en/stable/units/).
+
+These objects are all "array-like" in various ways (some more so than others),
+but none of them use the exact same underlying implementation as NumPy's ``ndarray``.
+Still, in cases where their functionality overlaps with NumPy arrays, in an ideal
+world it would be possible to interact with them using the same API.
+NumPy functions such as ``np.sin`` and ``np.concatenate`` should work when
+called on these alternative arrays by dispatching to implementations written
+by these third party libraries instead of coercing everything to NumPy arrays first.
+
+NumPy has already made some progress towards this goal, most notably with
+the proposed [``__numpy_ufunc__`` special method](http://docs.scipy.org/doc/numpy-dev/neps/ufunc-overrides.html).
+However, there are still some important details to be worked out, especially for
+[extending this approach to other NumPy functions](https://github.com/numpy/numpy/issues/4164).
+
+This project could have a large impact on the SciPy ecosystem, and should be straightforward to break into incremental tasks. From a technical perspective, implementing the desired functionality should not be especially challenging. However, determining the proper API design will require active engagement with the NumPy community and authors of these third party libraries (e.g., on mailing lists and GitHub). Interested students should have strong communication skills. Broad experience working with different libraries in the SciPy/PyData stack (including the above mentioned array libraries) would also be helpful.
+
+- Required knowledge: Python, C
+- Difficulty level: hard
+- Potential mentors: [Stephan Hoyer](http://github.com/shoyer)
+
+### Improved Dealing with overlapping input/output data
+
+Numpy operations where output arrays overlap with 
+input arrays can produce unexpected results.
+A simple example is
+```
+x = np.arange(100*100).reshape(100,100)
+x += x.T        # <- undefined result!
+```
+The task is to change Numpy so that the results
+here become similar to as if the input arrays
+overlapping with output were separate (here: `x += x.T.copy()`).
+The challenge here lies in doing this without sacrificing 
+too much performance or memory efficiency.
+
+Initial steps toward solving this problem were taken in
+https://github.com/numpy/numpy/pull/6166
+where a simplest available algorithm for detecting
+if arrays overlap was added. However, this is not yet
+utilized in ufuncs. An initial attempt to
+sketch what should be done is at https://github.com/numpy/numpy/issues/6272
+and issues referenced therein.
+
+- Required knowledge: C
+- Difficulty level: hard
+- Potential mentors: 

--- a/wiki/gsoc/2017-project-ideas.md
+++ b/wiki/gsoc/2017-project-ideas.md
@@ -1,0 +1,84 @@
+## Introduction
+
+This is the Google Summer of Code 2017 (GSoC'17) ideas page for SciPy.  The SciPy library is one of the core packages that make up the SciPy stack for scientific computing with Python. It provides many user-friendly and efficient numerical routines such as routines for numerical integration and optimization.
+
+This page lists a number of ideas for Google Summer of Code projects for SciPy, plus gives some pointers for potential GSoC students on how to get started with contributing and putting together their application. 
+
+### Guidelines & requirements
+
+SciPy will participate in GSoC'17 under the [umbrella of Python Software Foundation](http://python-gsoc.org).  Please read that page carefully, it contains important advice on the process.
+
+Also read [advice on writing a proposal](http://turnbull.sk.tsukuba.ac.jp/Blog/SPAM.txt#how-to-spam-in-detail) (written with the Mailman project in mind, but generally applicable)
+
+We expect from students that they're at least comfortable with Python (intermediate level). Some projects may also require Cython or C skills. Knowing how to use Git is also important; this can be learned before the official start of GSoC if needed though.
+
+### Getting started on SciPy
+
+Potential candidates should to take a look at [the guidelines on how to contribute to Scipy](http://scipy.github.io/devdocs/hacking.html). Making a small enhancement/bugfix/documentation fix/etc (does not need to be related to your proposal) to Scipy before applying for the GSoC is a hard requirement; it can help you get some idea how things will work during GSoC. 
+
+Start on your proposal early, post a draft to the mailing list and iterate based on the feedback you receive. This will not only improve the quality of your proposal, but also help you find a suitable mentor.
+
+
+## SciPy Project ideas
+
+### Make the SciPy test suite work with pytest
+
+SciPy currently uses ``nose`` for its test suite.  ``nose`` is not being maintained anymore, 
+and migrating the test suite so it works with ``pytest`` as well is important for future-proofing.
+Ideally as a result the test suite can be run with either of ``nose`` and ``pytest`` with all the bells and
+whistles, with fast/slow/xslow tests, skipifs and knownfailures. Further improvements like easily identifying tests that are too slow [gh-6989](https://github.com/scipy/scipy/issues/6989#issuecomment-279668168) should be feasible as well for a good student.
+
+This project will likely also require making changes in ``numpy.testing``.
+
+- Required knowledge: Python
+- Difficulty level: easy
+- Potential mentors: Evgeni Burovski, Ralf Gommers
+
+
+### Implement scipy.diff (numerical differentiation)
+
+Numerical derivative calculation methods are a set of core scientific numerical tools that are currently missing in SciPy. There has been discussion (and general agreement) on creating a new ``scipy.diff`` sub-package starting with the ``numdifftools`` code and some code in ``statsmodels`` (see https://github.com/scipy/scipy/issues/2035).
+The project would be roughly (1) familiarise yourself with the code and methods in `numdifftools` and `statsmodels` (and maybe look at equivalent packages in other languages), (2) define the API, specifically broadcasting behavior, to make sure it covers all major use cases efficiently, (3) implement `scipy.diff`, including tests and docs.
+Optionally, if there's time left, these methods could be used to compute Hesse and covariance matrices and fit parameter error in `scipy.optimize` or other packages like `statsmodels` or `lmfit` if they are considered out of scope for `scipy.optimize` for some reason.
+
+A private implementation of an important function that can be built upon (``approx_derivative``, see https://github.com/scipy/scipy/issues/6026) is already present in SciPy. 
+
+- Required knowledge: Python, numerical derivatives
+- Difficulty level: intermediate
+- Potential mentors: Matt Haberland, Ralf Gommers
+- Related reading: https://github.com/scipy/scipy/issues/2035, https://github.com/scipy/scipy/wiki/Proposal:-add-finite-difference-numerical-derivatives-as-scipy.diff
+
+
+### Improve the parabolic cylinder functions
+
+The parabolic cylinder functions are a family of special functions that have applications in PDEs and quadratures. SciPy has implementations of these functions (`special.pbdv`, `special.pbvv`, and `special.pbwa`), but significantly improved implementations are possible thanks to research advances in the last several years. The project would be to study a sequence of papers by Gil, Segura, and Temme and implement their algorithm for the parabolic cylinder functions from scratch in Cython.
+
+- Required knowledge: Cython, enough comfort with mathematics to learn about asymptotics and quadrature
+- Difficulty level: intermediate
+- Potential mentors: Josh Wilson
+- Related reading: https://dl.acm.org/citation.cfm?doid=1132973.1132978 (Only look at the paper! The license for the source code is incompatible with SciPy.)
+
+
+### Improve support for B-splines
+
+Recently a new ``BSpline`` class was added in SciPy.  This opened the way for many
+possible improvements and new features for working with splines.
+See https://github.com/scipy/scipy/issues/6730 and
+https://github.com/scipy/scipy/issues/6710 for a list of possible sub-projects
+of ranging difficulty. This project will require a student to be able to read
+relevant literature and get an understanding of the math.
+
+- Required knowledge: Python, Cython
+- Difficulty level: intermediate
+- Potential mentors: Evgeni Burovski, Ralf Gommers
+
+### Your own idea
+
+The above projects are just suggestions --- it is also very good to suggest a project idea of your own if you have something in mind that you want to do. Ask people on the [mailing list](http://scipy.org/scipylib/mailing-lists.html) for suggestions in this case.
+
+
+### And more...
+
+A set of additional new feature ideas can be found on the [Scipy Roadmap](http://scipy.github.io/devdocs/roadmap.html).
+
+

--- a/wiki/gsoc/2018-project-ideas.md
+++ b/wiki/gsoc/2018-project-ideas.md
@@ -1,0 +1,80 @@
+## Introduction
+
+This is the Google Summer of Code 2018 (GSoC'18) ideas page for SciPy.  The SciPy library is one of the core packages that make up the SciPy stack for scientific computing with Python. It provides many user-friendly and efficient numerical routines such as routines for numerical integration and optimization.
+
+This page lists a number of ideas for Google Summer of Code projects for SciPy, plus gives some pointers for potential GSoC students on how to get started with contributing and putting together their application. 
+
+### Guidelines & requirements
+
+SciPy will participate in GSoC'18 under the [umbrella of Python Software Foundation](http://python-gsoc.org).  Please read that page carefully, it contains important advice on the process.
+
+Also read [advice on writing a proposal](http://turnbull.sk.tsukuba.ac.jp/Blog/SPAM.txt#how-to-spam-in-detail) (written with the Mailman project in mind, but generally applicable)
+
+We expect from students that they're at least comfortable with Python (intermediate level). Some projects may also require Cython or C skills. Knowing how to use Git is also important; this can be learned before the official start of GSoC if needed though.
+
+### Getting started on SciPy
+
+Potential candidates should take a look at [the guidelines on how to contribute to Scipy](http://scipy.github.io/devdocs/hacking.html). Making a small enhancement/bugfix/documentation fix/etc (does not need to be related to your proposal) to Scipy before applying for the GSoC is a hard requirement; it can help you get some idea how things will work during GSoC. 
+
+Start on your proposal early, post a draft to the mailing list and iterate based on the feedback you receive. This will not only improve the quality of your proposal, but also help you find a suitable mentor.
+
+
+## SciPy Project ideas
+
+### Enhance the Randomized Numerical Linear Algebra functionality
+
+In SciPy 1.0 a first randomized linear algebra method was added, namely CountMin Sketch (`clarkson_woodruff_transformation`) for reducing the dimensionality of a vector space to an embedded space.
+
+Other widely used methods for subspace embedding (like the Johnson-Lindenstrauss) can be added, as well as algorithms that build on top of those subspace embedding methods for least squares regression or low rank approximation.
+
+- Required knowledge: Python, linear algebra
+- Difficulty level: medium
+- Potential mentors: Ralf Gommers
+
+### Rotation formalism in 3 dimensions
+
+#### General info
+- Required knowledge and skills: Python, understanding how to vectorize operations in numpy, ability to read and grasp papers/books on the subject
+- Difficult level: easy to medium
+- Potential mentors: Eric Larson, Nikolay Mayorov
+
+#### Description
+There are several ways to represent a rotation in 3-dimensional space: Euler angles, direction cosine (or rotation) matrices (DCM), quaternions, rotation vectors and some others. Different representations are preferable in different scenarios and there exists a correspondence between all of them. You can find a good overview in [1] and a more comprehensive treatment in [2]. Note that there are many different conventions in this field, one of which should be chosen and described properly. Also note that "rotation" and "orientation" can be used interchangeably: an orientation between two frames is determined by a rotation required to superimpose one frame onto another.
+
+The aim of this project is to create a module which will allow to conveniently describe, apply and compose rotations. The proposed module name is `scipy.spatial.rotation` or if are looking for wider perspectives `scipy.spatial.transform`. The content of this module is preliminarily seen as follows:
+
+1. The main class of the module may be called `Rotation`. 
+   1. It should represent an arbitrary rotation or several rotations (i.e. we should aim for vectorized approach for efficiency). 
+   2. It should be possible to create `Rotation` from any sensible representation and in vectorized fashion. The most widely used of them are listed above, more exotic parametrizations can also be considered.
+   3. Internally `Rotation` should use either DCMs or quaternions to represent rotations. Both of these choices are good with some minor pros and cons.
+   4. `Rotation` should be able to return any required representation, like for example we would like to know which Euler angles describe our rotation, etc. These representations can be returned as numpy arrays.
+   3. `Rotation` should have methods to rotate or project a vector or a set of vectors. See [3] to get an idea about the difference of this views. Overall it should be intuitive and clear for the user what he is doing with which operation (i.e. it should be explained sufficiently in the documentation). Also here we need to consider how vectorized operations are performed, i.e. one rotation on many vectors, many rotations on one vector and many rotations on many vectors (most likely we need 1-to-1 correspondence in this case).
+   4. `Rotation` should have a method (likely `__mul__`) to compute a representation of a consecutive application of two rotation, like `C = A * B`. If DCMs are used internally this composition comes down simply to matrix multiplication.
+   5. The main difficulty in implementing this class is to implement conversions between an arbitrary representation to/from the internal representation. There are some peculiar points.
+2. Apart from `Rotation` class we can include some useful algorithms regarding rotations. Some that I'm aware of:
+   1. Interpolation between orientations using SLERP algorithm [4].
+   2. Finding a rotation which gives the best match between the set of vectors measured in two frames. Note that some methods produce general orthogonal transformations, i.e., allow reflections [5].
+   3. "Cubic spline" interpolation for the set of orientations [6].
+   4. Optimal "averaging" of orientations [7].
+   5. Orthogonalization of a 3x3 matrix, one of simpler approaches is described in [8].
+   6. Uniform random sampling of rotations. One way to achieve this is to sample quaternions as unit vectors distributed uniformly on a unit sphere in 4D.
+
+#### References
+
+1. https://en.wikipedia.org/wiki/Rotation_formalisms_in_three_dimensions
+2. "A Survey of Attitude Representation" by Malcolm D. Shuster
+3. https://en.wikipedia.org/wiki/Rotation_matrix#Ambiguities
+4. https://en.wikipedia.org/wiki/Slerp#Quaternion_Slerp
+5. https://en.wikipedia.org/wiki/Wahba%27s_problem
+6. http://qspline.sourceforge.net/qspline.pdf
+7. "Quaternion Averaging" by F. Landis Markley et al.
+8. "Unit Quaternion from Rotation Matrix" by F. Landis Markley
+
+### Your own idea
+
+The above projects are just suggestions --- it is also very good to suggest a project idea of your own if you have something in mind that you want to do. Ask people on the [mailing list](http://scipy.org/scipylib/mailing-lists.html) for suggestions in this case.
+
+### And more...
+
+A set of additional new feature ideas can be found on the [Scipy Roadmap](http://scipy.github.io/devdocs/roadmap.html).
+

--- a/wiki/gsoc/2019-project-ideas.md
+++ b/wiki/gsoc/2019-project-ideas.md
@@ -1,0 +1,73 @@
+## Introduction
+
+This is the Google Summer of Code 2019 (GSoC'19) ideas page for SciPy.  The SciPy library is one of the core packages that make up the SciPy stack for scientific computing with Python. It provides many user-friendly and efficient numerical routines such as routines for numerical integration and optimization.
+
+This page lists a number of ideas for Google Summer of Code projects for SciPy, plus gives some pointers for potential GSoC students on how to get started with contributing and putting together their application. 
+
+### Guidelines & requirements
+
+SciPy plans to participate in GSoC'19 under the [umbrella of Python Software Foundation](http://python-gsoc.org). 
+
+We expect from students that they're at least comfortable with Python (intermediate level). Some projects may also require Cython or C skills. Knowing how to use Git is also important; this can be learned before the official start of GSoC if needed though.
+
+If you have an idea of what you would like to work on (see below for ideas) and are considering participating:
+
+1. Read the [PSF page](http://python-gsoc.org/) carefully, it contains important advice on the process.
+2. Read [advice on writing a proposal](http://turnbull.sk.tsukuba.ac.jp/Blog/SPAM.txt#how-to-spam-in-detail) (written with the Mailman project in mind, but generally applicable)
+3. Look at [the guidelines on how to contribute to Scipy](http://scipy.github.io/devdocs/hacking.html).
+4. Make a enhancement/bugfix/documentation fix -- it does not have to be big, and it does not need to be related to your proposal. Doing so before applying for the GSoC is a hard requirement for SciPy. It helps everyone you get some idea how things would work during GSoC.
+5. Start writing your proposal early, post a draft to the [scipy-dev mailing list](https://www.scipy.org/scipylib/mailing-lists.html) and iterate based on the feedback you receive. This will both improve the quality of your proposal and help you find a suitable mentor.
+
+### Contact
+
+If you have a question *after checking all guideline pages above*, you can email the [scipy-dev mailing list](https://www.scipy.org/scipylib/mailing-lists.html).
+
+## SciPy Project ideas
+
+### Revamp scipy.fftpack
+
+Revamping the `scipy.fftpack` interface will allow us to address a number of maintenance issues, and increase performance (both accuracy and speed). Possible goals and related benefits:
+
+- In general it would be good to have a backend system for various 3rd party fft implementations, such as [pyFFTW](https://github.com/pyFFTW/pyFFTW), [mkl-fft](https://github.com/IntelPython/mkl_fft), and possibly [CuPy](https://cupy.chainer.org/). These libraries provide various features such as pre-planned transforms, multi-threading, support for long-double precision and/or GPU support that do not exist in SciPy's fftpack. pyFFTW, mkl-fft and CuPy provide fftpack-compatible functions and it is possible to use pyFFTW to [monkeypatch SciPy](https://hgomersall.github.io/pyFFTW/sphinx/tutorial.html#monkey-patching-3rd-party-libraries). It would be preferable to instead have SciPy provide a formal backend interface for allowing 3rd party fft implementations to be used in place of scipy's fftpack.
+- Once a fft backend system has been defined, it would be useful to users provide some example of their use and relative performance (e.g. expanding scipy's existing fft benchmarks or providing IPython notebooks to demonstrate the relative performance).
+- A stretch goal related to the backend system would be to contribute to third party libraries such as pyFFTW to fill in existing gaps in their functionality to provide complete coverage of the functions currently available in scipy.fftpack. For pyFFTW and cupy, the gap is mainly in the lack of real-to-real transforms (discrete cosine transform and discrete sine transform).
+
+Outside of providing a system for handling different fft backends, there are other potential goals related to improving FFT support in SciPy.
+
+- NumPy now has [pocketfft](https://github.com/numpy/numpy/pull/11888), we should also have it for SciPy. Of particular interest regarding performance is the Bluestein algorithm (or chirp Z-transform), which we have been wanting to add to fftpack for a long time.
+- The APIs of numpy.fft and scipy.fftpack [should agree better](https://github.com/scipy/scipy/issues/2487). This is a lower priority because it's hard (requiring lots of discussion on impact on users if we deprecate things, etc.), but it's an important one as well. The large overlap with numpy.fft has to change (both are too widely used to deprecate one); in the documentation we should make clear that scipy.fftpack is preferred over numpy.fft. If there are differences in signature or functionality, the best version should be picked case by case (example: numpy’s rfft is preferred, see gh-2487).
+- We probably want to deprecate fftpack.convolve as a public function (it was not meant to be public). 
+
+This project will require in-depth API thinking, and robust, possibly extensive discussions with other devs on GitHub and the SciPy mailing lists. A basic familiarity with discrete Fourier transforms will be useful in understanding and contributing to the project.
+
+- Required knowledge: Python, linear algebra
+- Difficulty level: medium
+- Potential mentors: Gregory Lee and Eric Larson
+
+(Ideas and text adapted from [scipy-dev](https://mail.python.org/pipermail/scipy-dev/2018-December/023221.html) and the [scipy detailed roadmap](https://scipy.github.io/devdocs/roadmap-detailed.html#fftpack).)
+
+### Improve ODE solvers
+
+Since version 1.0 scipy includes a set of ODE [solvers](http://scipy.github.io/devdocs/generated/scipy.integrate.solve_ivp.html#scipy.integrate.solve_ivp) implemented in pure Python. It gives the advantage of the ease of their modification and extension. There are many possible ways to improve and refine the existing solver or implement new ones. The exact plan of work should be determined by a student, based on his or her expertise and interests. Here we list possible directions:
+
+1. Implement a test/benchmark suite of ODE/DAE problems. A good starting point is https://archimede.dm.uniba.it/~testset
+2. Implement DOP853 Runge-Kutta method. This high-order method, popular in celestial mechanics, has a rather complex math behind it and a non-trivial implementation. There exists a canonical Fortran [source code](http://www.unige.ch/~hairer/prog/nonstiff/dop853.f), however its literal translation into Python 
+doesn't seem a satisfactory or viable approach. Ideally, a student should produce a thorough and easy-to-understand theoretical derivation of the core formulas of the method as a part of his work. The ideas behing the method are explained in "Solving Ordinary Differential Equations, Part I". There is an [ongoing work](https://github.com/scipy/scipy/pull/9290), which is likely to be correct but needs to be checked, explained (in terms of math) and finished.
+3. Improve adaptive step-size control strategies for better computational stability and predictable behavior as suggested [here](https://github.com/scipy/scipy/issues/9822). This item is going to require a lot of experiments, tuning and ad-hoc decisions. A suite of test problems is going to be essential.
+4. Implement a solver of implicit differential equations and [differential-algebraic equations](https://en.wikipedia.org/wiki/Differential-algebraic_system_of_equations). A suitable form for such equations is ``M(t, y) y' = f(t, y)`` and in case of DAEs matrix `M(t, y)` is singular. It seems that this solver is better to be implemented as a separate function, focused on a high-quality implementation of a single algorithm. This task assumes selecting a suitable algorithm, its thorough understanding, API design, implementation and testing.
+5. Implement a solver of [delayed differential equations](https://en.wikipedia.org/wiki/Delay_differential_equation). There are several possible types and forms of such equations, a most appropriate of which must be selected. For the rest, this task is similar to the previous one.
+6. Student own ideas.
+
+A reasonable plan would be to work on 2 and either 1 and 3 or one of 4 and 5.
+
+- Required knowledge and skills: Python, strong background in mathematics or numerical methods, ability to grasp essential information from papers and books
+- Difficulty level: medium to high
+- Potentail mentors: Nikolay Mayorov, Peter Solfest
+
+### Your own idea
+
+The above projects are just suggestions --- it is also very good to suggest a project idea of your own if you have something in mind that you want to do. Ask people on the [mailing list](http://scipy.org/scipylib/mailing-lists.html) for suggestions in this case.
+
+### And more...
+
+A set of additional new feature ideas can be found on the [Scipy Roadmap](http://scipy.github.io/devdocs/roadmap.html).

--- a/wiki/gsoc/2021-project-ideas.md
+++ b/wiki/gsoc/2021-project-ideas.md
@@ -1,0 +1,129 @@
+## Introduction
+
+This is the Google Summer of Code 2021 (GSoC'21) ideas page for SciPy.  The SciPy library is one of the most widely used libraries for scientific computing with Python. It provides many user-friendly and efficient numerical routines for everything from linear algebra and numerical optimization to statistics and graph algorithms.
+
+This page lists a number of ideas for Google Summer of Code projects for SciPy, plus gives some pointers for potential GSoC students on how to get started with contributing and putting together their application. 
+
+### Guidelines & requirements
+
+SciPy plans to participate in GSoC'21 under the [umbrella of Python Software Foundation](http://python-gsoc.org). 
+
+We expect from students that they're at least comfortable with Python (intermediate level). Some projects may also require Cython or C skills. Knowing how to use Git is also important; this can be learned before the official start of GSoC if needed though.
+
+If you have an idea of what you would like to work on (see below for ideas) and are considering participating:
+
+1. Read the [PSF page](http://python-gsoc.org/) carefully, it contains important advice on the process.
+2. Read [advice on writing a proposal](http://turnbull.sk.tsukuba.ac.jp/Blog/SPAM.txt#how-to-spam-in-detail) (written with the Mailman project in mind, but generally applicable)
+3. Look at [the guidelines on how to contribute to SciPy](http://scipy.github.io/devdocs/dev/hacking.html).
+4. Make a enhancement/bugfix/documentation fix -- it does not have to be a large PR, and it does not need to be related to your proposal. Doing so before applying for the GSoC is a hard requirement for SciPy. It helps everyone by providing some idea on how things would work during GSoC.
+5. Start writing your proposal early, post a draft to the [scipy-dev mailing list](https://www.scipy.org/scipylib/mailing-lists.html) and iterate based on the feedback you receive. This will both improve the quality of your proposal and help you find a suitable mentor.
+
+### Contact
+
+If you have a question *after checking all guideline pages above*, you can email the [scipy-dev mailing list](https://www.scipy.org/scipylib/mailing-lists.html).
+
+## SciPy Project ideas
+
+### Improve performance through use of Pythran or Cython
+
+SciPy has long used [Cython](https://cython.org/) as a tool to improve performance of code that would be too slow as pure Python. More recently we added experimental support for [Pythran](https://github.com/serge-sans-paille/pythran), to make it easier to accelerate Python code. Furthermore we use [Airspeed Velocity](https://asv.readthedocs.io/) for performance benchmarking (see [code](https://github.com/scipy/scipy/tree/master/benchmarks) and [published results](https://pv.github.io/scipy-bench/)). This project may include:
+
+- writing new benchmarks for functionality in SciPy,
+- accelerating algorithms with Pythran or Cython,
+- if the student sees opportunities to do so: improve the documentation or contributor workflow around writing and running benchmarks
+
+Functionality in any SciPy submodule that is performance sensitive can be worked on. Modules like `scipy.stats` and `scipy.optimize` have a lot of algorithms that could be accelerated.
+
+- Required knowledge: Python is required, experience with C/C++/Pythran/Cython or benchmarking tools is helpful but not required
+- Difficulty level: easy-medium
+- Potential mentors: Ralf Gommers, Serge Guelton
+
+
+### Add type annotations to a submodule
+
+NumPy 1.20 (Dec'20) was the first NumPy release with support for type annotations. This makes it possible to add type annotations to SciPy as well. Early examples include [this PR for `spatial.distance`](https://github.com/scipy/scipy/pull/13448) and [these annotations for `stats.qmc`](https://github.com/scipy/scipy/blob/master/scipy/stats/_qmc.pyi). Because type annotations are so new and SciPy wasn't designed with them in mind, this project may be more challenging than expected. The project may include:
+
+- Writing type annotations for a submodule
+- Ensuring we can test type annotations in continuous integration with Mypy
+- If needed, report issues or contribute improvements to NumPy's type annotations
+
+- Required knowledge: Python is required, experience with Mypy or knowledge of type systems is helpful but not required
+- Difficulty level: medium
+- Potential mentors: Ralf Gommers, Melissa Weber Mendonça
+
+
+### Experiment with transitioning SciPy to a new build system
+
+SciPy is currently built with `numpy.disutils`, which relies on `distutils` and `setuptools`. `distutils` is deprecated, and will be removed in Python 3.12 in ~2.5 years time. Transitioning from `disutils` to `setuptools` is a fair amount of work. And because that would still leave us with a very poor build system, now is a good time to explore switching to a better build system. Meson and CMake are the two obvious candidates. Benefits would include: faster/parallel builds, better support for cross-compiling, less maintenance both for SciPy's build tooling and for `numpy.distutils`. Meson seems preferred because of its better docs and clean pure Python codebase, although CMake can be explored in the proposal phase too. The goal of this project is to get SciPy to build with Meson, so we can make an informed decision about switching to it. Activities may include:
+- Making a choice about build system together with SciPy maintainers and input from the wider community (this conversation could be started before the coding period)
+- Doing a small proof-of-concept with one or a couple of SciPy submodules
+- Extending to more submodules, ensuring we cover different languages and code generation patterns
+- Identifying and discussing solutions to issues for distributing SciPy (e.g. on PyPI and conda-forge), as well as developer workflows.
+
+See https://github.com/scipy/scipy/issues/13615 for more details.
+
+This is a challenging project, which could have a major impact on SciPy if it's successful. 
+
+- Required knowledge: Python, as well as at least some experience building C, C++, Cython or Fortran code, are required
+- Difficulty level: hard
+- Potential mentors: Ralf Gommers, Matti Picus
+
+### Object-oriented design of digital filtering in scipy.signal
+
+Digital filters design, analysis and signal filtering are core functionalities of `scipy.signal`. The design approach and naming conventions there are largely adopted from MATLAB. While it was a good approach for the initial stages of development, now it seems somewhat dated, convoluted and hard to use, especially for people without MATLAB background or when simple filtering with minimum efforts is needed ("non expert usage").
+
+The scope of this project is to condense all functionality related to digital filters into an easy-to-use class and possibly accompanying functions. It will involve writing new code as well as reusing (wrapping) existing functions.
+
+By a linear digital filter we mean a single-input single-output system which implements a linear difference equation and can be fully described by its impulse response (also called a linear time-invariant system).
+
+The proposed design is similar to the design of `scipy.spatial.transform.Rotation` and follows "object focused" section in this [issue](https://github.com/scipy/scipy/issues/6137). The digital filter is represented by `DigitalFilter` or simply `Filter` class, which encapsulates internal representation of the filter and has the following core functionality:
+
+- Initialize from and convert to commonly used representations
+    * Transfer function coefficients (a and b, or denominator and numerator): `from_tf`/`as_tf`.
+    * Zeros, poles and gain: `from_zpk`/`as_zpk`.
+    * Sequence of second order sections: `from_sos`/`as_sos`.
+    * State-space representation matrices: `from_ss`/`as_ss` - possibly
+- Combining filters
+    * To combine two filters in cascade we can use `__mul__` operator: `C = A * B` also `C = 0.5 * A` - gain adjustment
+    * To combine two filters in parallel we can use `__add__` operator: `C = A + B`
+- Query filter properties
+    * Frequency response
+    * Group delay
+    * Impulse response
+    * Step response
+- Filter a signal. Most likely a single method `filter` or `__call__` should be provided, but which can be supplied with additional arguments
+    * Default call should implement `lfilter` logic
+    * Initial conditions can be supplied, covering `lfiltlc, lfilter_zi` and maybe some other logic
+    * Filtering with zero phase shift with `filtfilt` logic 
+    * With linear-phase FIR filters, a result similar to `filtfilt` can be achieved by shifting the output by the fixed number of taps (constant group delay), perhaps such logic could also be activated with an argument
+
+More difficult subject is whether new filter design functionality should be provided or we should stick to existing functions. I think that "non expert usage" filter design functionality is clearly lacking and generally everything can be done more elegant, clean and concise, but it will require significant work and expert knowledge.
+
+New filter design functionality could be implemented as class (factory) methods or as standalone functions. For the updated filter design functionality I think we should strive for the following:
+
+- Functions or methods and their arguments have good, descriptive names
+- Few entry points and good conceptual generalization
+- Arguments should be intuitive and have good default values. Maybe special "no expert usage" functions or methods should exist. For example, a user should not think how many coefficients he needs to create a reasonably good low-pass FIR filter with a given cutoff frequency. Low-pass filtering with delayed compensation should be done with a short line of code with minimum thinking. Something like that `DigitalFilter.simple_fir(cutoff=0.1).filter(x, compensate_delay=True)`
+- Consistent and logical approach to frequency specification. Probably the best idea is to accept the sampling frequency for more intuitive treatment, but set it to 1 by default which will mean that all frequencies are measured as fractions of the sampling frequency, i. e. "normalized frequency" in cycle/sample is used.
+
+Project summary:
+
+- Required knowledge: Python, API design, experience and interest in Digital Signal Processing
+- Difficulty level: medium-hard
+- Potential mentors: Nikolay Mayorov
+
+### Integrate library UNU.RAN into scipy.stats
+
+The goal is to integrate the functionality of the C library UNU.RAN (http://statmath.wu.ac.at/software/unuran/) into SciPy. UNU.RAN is a C library that contains a collection of algorithms for generating non-uniform pseudorandom variates. It is designed to provide a consistent tool to sample from distributions with various properties. Its emphasis is on the generation of non-standard distributions. Since there is no universal method that fits for all situations, various methods for sampling are implemented. Adding such methods to scipy.stats would help to improve the available functionality for random variate generation.
+
+- Required knowledge: Experience with Python, C / Cython and knowledge in probability theory / statistics is required. 
+- Difficulty level: medium-hard
+- Potential mentors: Christoph Baumgarten, Nicholas McKibben
+
+### Your own idea
+
+The above projects are just suggestions --- it is also very good to suggest a project idea of your own if you have something in mind that you want to do. Ask people on the [mailing list](http://scipy.org/scipylib/mailing-lists.html) for suggestions in this case.
+
+### And more...
+
+A set of additional new feature ideas can be found on the [SciPy detailed Roadmap](http://scipy.github.io/devdocs/roadmap-detailed.html).

--- a/wiki/gsoc/2022-project-ideas.md
+++ b/wiki/gsoc/2022-project-ideas.md
@@ -1,0 +1,149 @@
+## Introduction
+
+This is the Google Summer of Code 2022 (GSoC'22) ideas page for SciPy.  The SciPy library is one of the most widely used libraries for scientific computing with Python. It provides many user-friendly and efficient numerical routines for everything from linear algebra and numerical optimization to statistics and graph algorithms.
+
+This page lists a number of ideas for Google Summer of Code projects for SciPy, plus gives some pointers for potential GSoC students on how to get started with contributing and putting together their application. 
+
+### Guidelines & requirements
+
+SciPy plans to participate in GSoC'22 under the [umbrella of Python Software Foundation](http://python-gsoc.org). 
+
+We expect from students that they're at least comfortable with Python (intermediate level). Some projects may also require Cython or C skills. Knowing how to use Git is also important; this can be learned before the official start of GSoC if needed though.
+
+If you have an idea of what you would like to work on (see below for ideas) and are considering participating:
+
+1. Read the [PSF page](http://python-gsoc.org/) carefully, it contains important advice on the process.
+2. Read [advice on writing a proposal](http://turnbull.sk.tsukuba.ac.jp/Blog/SPAM.txt#how-to-spam-in-detail) (written with the Mailman project in mind, but generally applicable)
+3. Look at [the guidelines on how to contribute to SciPy](http://scipy.github.io/devdocs/dev/hacking.html).
+4. Make a enhancement/bugfix/documentation fix -- it does not have to be a large PR, and it does not need to be related to your proposal. Doing so before applying for the GSoC is a hard requirement for SciPy. It helps everyone by providing some idea on how things would work during GSoC.
+5. Start writing your proposal early, post a draft to the [scipy-dev mailing list](https://mail.python.org/mailman3/lists/scipy-dev.python.org/) and iterate based on the feedback you receive. This will both improve the quality of your proposal and help you find a suitable mentor.
+
+### Contact
+
+If you have a question *after checking all guideline pages above*, you can email the [scipy-dev mailing list](https://mail.python.org/mailman3/lists/scipy-dev.python.org/).
+
+## SciPy Project ideas
+
+
+### f2py improvements
+
+#### Restructuring the F2PY frontend
+- The plan is to migrate the front-end to `argparse`
+- Subsequently, as part of the `np.distutils` deprecation, the goal is to replace the build system with generators for `meson` and `cmake`
+
+Within scope will also be improvements to the `meson` support and enabling extended compilers. In particular, LLVM based Intel, LFortran and Flang should be usable with the new CLI interface.
+
+
+- Required knowledge: Understanding of build systems (`meson`, `cmake`), `argparse` CLI design, testing
+- Project length: 175 hours
+- Difficulty level: Low-Medium
+- Potential mentors: Rohit Goswami
+
+#### Unifying F2PY C structures with NumPy-C
+
+
+- Since the `meson` conversion, only `pyf` files are used.
+- The code-generation should be cleaner to reduce the warnings under `gcc` and `clang`
+
+Subsequently, we intend to work on improvements to the `f2py` `pyf` file format. Ideally, the goal is to reduce or eliminate `usercode` blocks within the signature files.
+
+
+- Currently certain types are replicated in NumPy and F2PY, e.g. `complex`, the goal is to reduce the maintainability burden of `f2py` by using more of the NumPy-C API
+- From SciPy's perspective, consider `fitpack.pyf` which defines (in `C`) local `typedef`s
+  + Some of these make more sense in the context of the relatively newer `.f2py_f2cmap` dictionary
+- Extensions include cleaning up the `fortranobject` code
+   + In particular, moving to the limited API for ABI compatibility across versions
+
+Tests are also required for this portion of the code-base.
+
+- Required knowledge: Python-C API, NumPy-C API, some interest in understanding how Fortran maps to C structures
+- Project length: 350 hours
+- Difficulty level: Medium-Hard
+- Potential mentors: Rohit Goswami
+
+#### Fortran Python interoperability extensions
+- Generating `ufuncs` for elemental functions
+- Improving code-generation, by using f-strings instead of the global dictionary structure
+- Adding support for coarrays and teams via MPI [extension]
+ 
+This more open ended, there are a lot of features to support and there will be overlap with compiler projects.
+
+- Required knowledge: Understanding of new Fortran features, and extensive familiarity with the NumPy-C API, interest in parallel computing
+- Project length: 350 hours
+- Difficulty level: Hard
+- Potential mentors: Rohit Goswami
+
+### Object-oriented design of digital filtering in scipy.signal
+
+**NOTE: not yet updated from last year, TBD if this is still a potential idea**
+
+Digital filters design, analysis and signal filtering are core functionalities of `scipy.signal`. The design approach and naming conventions there are largely adopted from MATLAB. While it was a good approach for the initial stages of development, now it seems somewhat dated, convoluted and hard to use, especially for people without MATLAB background or when simple filtering with minimum efforts is needed ("non expert usage").
+
+The scope of this project is to condense all functionality related to digital filters into an easy-to-use class and possibly accompanying functions. It will involve writing new code as well as reusing (wrapping) existing functions.
+
+By a linear digital filter we mean a single-input single-output system which implements a linear difference equation and can be fully described by its impulse response (also called a linear time-invariant system).
+
+The proposed design is similar to the design of `scipy.spatial.transform.Rotation` and follows "object focused" section in this [issue](https://github.com/scipy/scipy/issues/6137). The digital filter is represented by `DigitalFilter` or simply `Filter` class, which encapsulates internal representation of the filter and has the following core functionality:
+
+- Initialize from and convert to commonly used representations
+    * Transfer function coefficients (a and b, or denominator and numerator): `from_tf`/`as_tf`.
+    * Zeros, poles and gain: `from_zpk`/`as_zpk`.
+    * Sequence of second order sections: `from_sos`/`as_sos`.
+    * State-space representation matrices: `from_ss`/`as_ss` - possibly
+- Combining filters
+    * To combine two filters in cascade we can use `__mul__` operator: `C = A * B` also `C = 0.5 * A` - gain adjustment
+    * To combine two filters in parallel we can use `__add__` operator: `C = A + B`
+- Query filter properties
+    * Frequency response
+    * Group delay
+    * Impulse response
+    * Step response
+- Filter a signal. Most likely a single method `filter` or `__call__` should be provided, but which can be supplied with additional arguments
+    * Default call should implement `lfilter` logic
+    * Initial conditions can be supplied, covering `lfiltlc, lfilter_zi` and maybe some other logic
+    * Filtering with zero phase shift with `filtfilt` logic 
+    * With linear-phase FIR filters, a result similar to `filtfilt` can be achieved by shifting the output by the fixed number of taps (constant group delay), perhaps such logic could also be activated with an argument
+
+More difficult subject is whether new filter design functionality should be provided or we should stick to existing functions. I think that "non expert usage" filter design functionality is clearly lacking and generally everything can be done more elegant, clean and concise, but it will require significant work and expert knowledge.
+
+New filter design functionality could be implemented as class (factory) methods or as standalone functions. For the updated filter design functionality I think we should strive for the following:
+
+- Functions or methods and their arguments have good, descriptive names
+- Few entry points and good conceptual generalization
+- Arguments should be intuitive and have good default values. Maybe special "no expert usage" functions or methods should exist. For example, a user should not think how many coefficients he needs to create a reasonably good low-pass FIR filter with a given cutoff frequency. Low-pass filtering with delayed compensation should be done with a short line of code with minimum thinking. Something like that `DigitalFilter.simple_fir(cutoff=0.1).filter(x, compensate_delay=True)`
+- Consistent and logical approach to frequency specification. Probably the best idea is to accept the sampling frequency for more intuitive treatment, but set it to 1 by default which will mean that all frequencies are measured as fractions of the sampling frequency, i. e. "normalized frequency" in cycle/sample is used.
+
+Project summary:
+
+- Required knowledge: Python, API design, experience and interest in Digital Signal Processing
+- Project length: 175 hours
+- Difficulty level: medium-hard
+- Potential mentors: Nikolay Mayorov
+
+### PyData/Sparse C++ Rewrite
+[PyData/Sparse](https://github.com/pydata/sparse/) is a sparse array library that provides N-dimensional sparse arrays in the `COO`, `DOK` and a generalized version of the `CSR` format for N dimensions. We plan to re-write the library with a solid theoretical foundation for optimized run-time performance. There is an attempt underway at [this repository](https://github.com/hameerabbasi/xsparse/).
+
+The ideas implemented are mainly taken from the [TACO papers by Fred Kjølstäd](https://arxiv.org/search/?query=Kjolstad%2C+F&searchtype=author&abstracts=show&order=-announced_date_first&size=50), but these will often be extended and modified as needed.
+
+The general plan of attack will be as follows:
+
+* Read/understand the TACO papers, particularly [this one](https://arxiv.org/abs/1804.10112).
+* Discuss with your mentor how you would convert the code generation approaches into compile-time templated C++.
+* Learn to explore and extend these approaches to cover other methods not explained in these papers, such as reshaping, transposing and partial evaluation.
+* Implement these approaches as you learn.
+* (Stretch goal) Write a cppyy wrapper and expose the NumPy API with this wrapper.
+
+Project summary:
+
+- Required knowledge: C++ templates, API design, interest in researching sparse arrays
+- Project length: 350 hours
+- Difficulty level: hard
+- Potential mentors: Hameer Abbasi, [Gagandeep Singh](https://github.com/czgdp1807) (co-mentor)
+
+### Your own idea
+
+The above projects are just suggestions --- it is also very good to suggest a project idea of your own if you have something in mind that you want to do. Ask people on the [mailing list](https://mail.python.org/mailman3/lists/scipy-dev.python.org/) for suggestions in this case.
+
+### And more...
+
+A set of additional new feature ideas can be found on the [SciPy detailed Roadmap](https://scipy.github.io/devdocs/dev/roadmap-detailed.html).

--- a/wiki/gsoc/discrete-wavelet-transform.md
+++ b/wiki/gsoc/discrete-wavelet-transform.md
@@ -1,0 +1,90 @@
+### Personal Info :
+
+Name : Ankit Agrawal  
+Email : aaaagrawal@iitb.ac.in  
+github : [ankit-maverick](https://github.com/ankit-maverick)  
+IRC nick : ankit_agrawal  
+Skype : aaaagrawal  
+Blog :  http://waveletsinscipy.blogspot.com/
+GSoC RSS Feed :  http://waveletsinscipy.blogspot.com/feeds/posts/default/-/GSoC/?alt=rss
+Telephone : Provided upon request  
+Timezone : IST (UTC +5:30)  
+University : Indian Institute of Technology(IIT), Bombay  
+Major : Electrical Engineering with Masters in Communication and Signal Processing  
+Current Year : Fourth year  
+Expected Graduation date : June 2015  
+Degree : Dual Degree(Bachelors + Masters in 5 yrs)   
+
+
+
+### Personal Bio :
+I am Ankit Agrawal, a fourth year student enrolled in a 5 year Dual Degree Program(B.Tech and Masters) in Electrical Engineering at IIT Bombay. My Masters specialization is in Communication and Signal Processing and I will pursue my Master's thesis along the lines of Machine Learning and Computer Vision. The relevant coursework that I have done in the past related to this project are Linear Algebra, Signals and Systems, Digital Signal Processing, Image Processing, Wavelets and Filter Banks*, Matrix Computations*, Probability and Stochastic Processes etc. I participated in GSoC 2013 under PSF with scikit-image, where I implemented some Image Feature Detectors and Binary Feature Descriptors(http://skimager.blogspot.in/). I have also made some minor contributions to other open source libraries in Python while peeking into specific parts of their codebase.
+
+
+### Proposal Title :
+#### SciPy : Discrete Wavelet Transforms and related algorithms  
+
+
+### Proposal Abstract :
+Discrete Wavelet Transform has been one of the important features missing from scipy.signal module and is a milestone in the Scipy 1.0 roadmap [1]. This project will start off by integrating the rgommers/pywt fork of the existing PyWavelets project into scipy.signal after some important API changes, followed by the implementation of 1D and 2D inverse Stationary Wavelet Transform. A private module of pywt will be included in scikit-image to support Image denoising algorithms like Sureshrink and Co. while preserving its compatibility with older scipy versions. Finally, a tutorial outlining some applications of Wavelets will be created for the general user to go through.
+
+
+### Timeline :
+
+##### Community Bonding period (21st April - 18th May):
+* Reading papers more thoroughly and discussing implementation details
+* Getting more familiar with the code-base
+
+##### Week 1 and 2 (19th May - 1st June)
+* API changes. This would involve introducing a new class for objects returned by wavedec function, adding idwtn and other changes discussed at [2].
+
+##### Week 3 (2nd June - 8th June)
+* Migrating rgommers/pywt into scipy.signal.
+* Improving docs and adding a small tutorial describing how the API can be pipelined to perform some simple tasks using Wavelets. 
+
+##### Week 4 and 5 (9th June - 22nd June)
+* Introducing a private module _pywt into scikit-image to preserve scikit-image's compatibility with older scipy versions
+* Modify and merge @thearn's PR[3] containing BayesShrink and VisuShrink on top of the _pywt module.
+
+##### Mid-term Evaluation (23rd June - 27th June)
+* Buffer period for completing any incomplete work
+
+##### Week 6 (28th June - 4th July)
+* 1d and 2d Inverse Stationary Wavelet Transform(iswt and iswt2).
+
+##### Week 7, 8, 9 and 10(5th July - 3rd Aug)
+* Implementing SureShrink Denoising method[4]
+* Implementing wavelet based image compression algorithms[5]
+
+##### Week 11 (4th Aug - 10th Aug)
+* Creating a tutorial that illustrates how Wavelets can be used in applications like Signal and Image Denoising and Compression, Time Series data Forecasting etc.
+
+##### Week 12 - Pencils Down Date (11th Aug - 17th Aug)
+* Buffer Period for completing any incomplete work
+* Making sure the existence of good test coverage and documentation
+
+##### Endterm Evaluation (18th Aug - 22nd Aug)
+
+
+### Patches :
+* Correcting the normalization of chebwin window function(https://github.com/scipy/scipy/pull/3433)
+* Taking on API issues in rgommers/pywt (https://github.com/rgommers/pywt/pull/49)
+
+
+### Schedule Information :
+My endterms for the current semester would end around 3rd May. My next semester would start in the last week of July and even though I would be able to devote at least 3-4 hrs a day during this period(because I have only 3 elective courses remaining to take), I would start coding by the 2nd week of May i.e. during the Community Bonding period to get a good head-start.  
+
+
+### References and Links :
+
+[(1)](https://github.com/scipy/scipy/pull/2908/files#diff-e79eb3278b3f95f251c02522330d7b1aR232) DWT in Scipy 1.0 Roadmap 
+
+[(2)](https://github.com/rgommers/pywt/issues/38) rgommers/pywt/#38 : API issues to discuss or change
+
+[(3)](https://github.com/scikit-image/scikit-image/pull/760) scikit-image/#760 : Implemented Wavelet Filter
+
+[(4)](https://groups.google.com/forum/#!searchin/pywavelets/iswt/pywavelets/bNFdhb6D5r0/9LnLdpW-PCsJ) Mike Marino's implementation of 1d iswt
+
+[(5)](http://statweb.stanford.edu/~imj/WEBLIST/1995/ausws.pdf) Adapting to Unknown Smoothness via Wavelet Shrinkage
+
+[(6)](http://www.mathworks.com/help/wavelet/index.html) Matlab Wavelet Toolbox

--- a/wiki/gsoc/rotation-formalism.md
+++ b/wiki/gsoc/rotation-formalism.md
@@ -1,0 +1,46 @@
+### Authors: 
+- [Vishal Gupta](https://py-ranoid.github.io/Resume) (student,UTC+5:30) 
+- Nikolay Mayorov (mentor)
+
+#### Created: 2018-02-25
+
+***
+
+### Rotation formalism in 3 dimensions
+
+#### General info
+- Required knowledge and skills: Python, understanding how to vectorize operations in numpy, ability to read and grasp papers/books on the subject
+- Difficult level: easy to medium
+- Potential mentors: Eric Larson, Nikolay Mayorov
+
+#### Description
+There are several ways to represent a rotation in 3-dimensional space: Euler angles, direction cosine (or rotation) matrices (DCM), quaternions, rotation vectors and some others. Different representations are preferable in different scenarios and there exists a correspondence between all of them. You can find a good overview in [1] and a more comprehensive treatment in [2]. Note that there are many different conventions in this field, one of which should be chosen and described properly. Also note that "rotation" and "orientation" can be used interchangeably: an orientation between two frames is determined by a rotation required to superimpose one frame onto another.
+
+The aim of this project is to create a module which will allow to conveniently describe, apply and compose rotations. The proposed module name is `scipy.spatial.rotation` or if are looking for wider perspectives `scipy.spatial.transform`. The content of this module is preliminarily seen as follows:
+
+1. The main class of the module may be called `Rotation`. 
+   1. It should represent an arbitrary rotation or several rotations (i.e. we should aim for vectorized approach for efficiency). 
+   2. It should be possible to create `Rotation` from any sensible representation and in vectorized fashion. The most widely used of them are listed above, more exotic parametrizations can also be considered.
+   3. Internally `Rotation` should use either DCMs or quaternions to represent rotations. Both of these choices are good with some minor pros and cons.
+   4. `Rotation` should be able to return any required representation, like for example we would like to know which Euler angles describe our rotation, etc. These representations can be returned as numpy arrays.
+   3. `Rotation` should have methods to rotate or project a vector or a set of vectors. See [3] to get an idea about the difference of this views. Overall it should be intuitive and clear for the user what he is doing with which operation (i.e. it should be explained sufficiently in the documentation). Also here we need to consider how vectorized operations are performed, i.e. one rotation on many vectors, many rotations on one vector and many rotations on many vectors (most likely we need 1-to-1 correspondence in this case).
+   4. `Rotation` should have a method (likely `__mul__`) to compute a representation of a consecutive application of two rotation, like `C = A * B`. If DCMs are used internally this composition comes down simply to matrix multiplication.
+   5. The main difficulty in implementing this class is to implement conversions between an arbitrary representation to/from the internal representation. There are some peculiar points.
+2. Apart from `Rotation` class we can include some useful algorithms regarding rotations. Some that I'm aware of:
+   1. Interpolation between orientations using SLERP algorithm [4].
+   2. Finding a rotation which gives the best match between the set of vectors measured in two frames [5].
+   3. "Cubic spline" interpolation for the set of orientations [6].
+   4. Optimal "averaging" of orientations [7].
+   5. Orthogonalization of a 3x3 matrix, one of simpler approaches is described in [8].
+   6. Uniform random sampling of rotations. One way to achieve this is to sample quaternions as unit vectors distributed uniformly on a unit sphere in 4D.
+
+#### References
+
+1. https://en.wikipedia.org/wiki/Rotation_formalisms_in_three_dimensions
+2. "A Survey of Attitude Representation" by Malcolm D. Shuster
+3. https://en.wikipedia.org/wiki/Rotation_matrix#Ambiguities
+4. https://en.wikipedia.org/wiki/Slerp#Quaternion_Slerp
+5. https://en.wikipedia.org/wiki/Wahba%27s_problem
+6. http://qspline.sourceforge.net/qspline.pdf
+7. "Quaternion Averaging" by F. Landis Markley et al.
+8. "Unit Quaternion from Rotation Matrix" by F. Landis Markley

--- a/wiki/gsoc/scipy-diff.md
+++ b/wiki/gsoc/scipy-diff.md
@@ -1,0 +1,369 @@
+#Proposal: add finite difference numerical derivatives as ``scipy.diff``
+
+* Authors: Maniteja Nandana(student)
+           Christoph Deil(mentor)
+* Date Created: 2015-03-09
+* Date Last Revised: 2015-03-24
+* Status: methods / API discussion
+* Potentially related issues: [#2035](https://github.com/scipy/scipy/issues/2035)
+
+This is very much work in progress (see open questions at the end).
+
+Feedback on scipy-dev or Github as well as co-authors welcome!
+
+##Abstract
+
+We propose to add a ``scipy.diff`` sub-package containing several finite difference numerical methods to
+compute derivatives of functions. Roughly analogous to the existing ``scipy.integrate`` ([tutorial](http://docs.scipy.org/doc/scipy-dev/reference/tutorial/integrate.html),
+[reference](http://docs.scipy.org/doc/scipy-dev/reference/integrate.html))
+sub-package that contains various numerical integration methods.
+
+There have been discussions on a potential ``scipy.diff`` over the past year on the scipy-dev mailing list and has been discussion in [issue 2035](https://github.com/scipy/scipy/issues/2035) about the need for methods to be able to compute derivatives in Scipy.
+
+The purpose of this document is to have a concrete API and method specification, to be implemented during [Google Summer of code 2015](https://www.google-melange.com/gsoc/homepage/google/gsoc2015) under [scipy.diff project idea](https://github.com/scipy/scipy/wiki/GSoC-2015-project-ideas#implement-scipydiff-numerical-differentiation)
+
+-------------------------------------------------------------------------------
+##Introduction
+
+To make sure everyone is on the same page, here's some motivation why we think ``scipy.diff``
+should be added as well as background info on notation and differentiation methods.
+
+###Motivation
+
+Most scientific computing libraries contain functions for numerical differentiation.
+
+####Numpy
+1. [numpy.diff](http://docs.scipy.org/doc/numpy/reference/generated/numpy.diff.html)
+2. [numpy.gradient](http://docs.scipy.org/doc/numpy/reference/generated/numpy.gradient.html)
+
+####Scipy
+1. [scipy.misc.derivative](http://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.derivative.html)
+2. [scipy.misc.central_diff_weights](http://docs.scipy.org/doc/scipy-dev/reference/generated/scipy.misc.central_diff_weights.html)
+
+But the methods in ``numpy`` and ``scipy`` were recently introduced and are insufficient for many applications where precise derivative estimates are needed.
+
+There are suitable methods implemented in 
+
+####statsmodels.tools.numdiff 
+
+[*Reference*](https://github.com/statsmodels/statsmodels/blob/master/statsmodels/tools/numdiff.py)
+
+####numdifftools
+[*Reference*](https://github.com/pbrod/numdifftools)
+
+we feel that moving those and adding extra ones to ``scipy.diff`` would benefit Scipy itself (they could be used e.g. in ``scipy.stats`` or ``scipy.optimize``) as well as the scientific Python community (avoid everyone rolling their own).
+
+
+###Notation
+
+For a function ![equation](http://i.imgur.com/fObhHT2.png) the [derivative](http://en.wikipedia.org/wiki/Derivative) is defined as ![equation](http://i.imgur.com/vm4DiSA.png)
+
+For multi-variate functions ![equation](http://i.imgur.com/1t6onPj.png) we denote the [partial derivatives](http://en.wikipedia.org/wiki/Partial_derivative) as ![equation](http://i.imgur.com/eCWd58V.png)
+
+For higher-order derivatives we use the notation ![equation](http://i.imgur.com/4xwkPos.png) for
+[univariate functions](http://en.wikipedia.org/wiki/Derivative#Higher_derivatives)
+
+and ![equation](http://i.imgur.com/FYiHID6.png) for [multivariate functions](http://en.wikipedia.org/wiki/Partial_derivative#Higher_order_partial_derivatives)
+
+``Note``: we do **not** plan to directly support [multi-valued functions](http://en.wikipedia.org/wiki/Multivariable_calculus) ![equation](http://i.imgur.com/hOXhpab.png) in the ``scipy.diff`` API. Users that want to compute derivatives of such functions can loop over and process one single-valued component function ![equation](http://i.imgur.com/tffmULg.png) at a time.
+
+###Methods
+
+There are different methods to compute derivatives that greatly vary in terms of
+generality (which functions they can be used for), speed and precision([comment](https://github.com/scipy/scipy/issues/2035#issuecomment-23628615))
+
+Here we'd like to mention and briefly discuss these:
+
+1. [Symbolic differentiation](http://en.wikipedia.org/wiki/Symbolic_computation)
+2. [Automatic differentiation](http://en.wikipedia.org/wiki/Automatic_differentiation)
+3. [Finite differences](http://en.wikipedia.org/wiki/Finite_difference)
+
+####Symbolic differentiation
+
+If your function is given by an analytic formula ![equation](http://i.imgur.com/cWifAAV.png)
+it is usually possible to compute the formula for the derivatives ![equation](http://i.imgur.com/5bM2AeQ.png)
+and ![equation](http://i.imgur.com/fOMqwEc.png)
+
+Implementing these derivatives as separate functions results in very fast and precise
+derivative computations and using them as part of your application.(e.g.
+[scipy.optimize.minimize](http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html)
+accepts `jac` and `hess` functions to compute first and second order
+derivatives for a given function `fun`)
+
+Computing the derivative formulas can be done with
+[symbolic computation](http://en.wikipedia.org/wiki/Symbolic_computation) tools like
+[Sympy](http://www.sympy.org/), even auto-generating and evaluating derivatives as part of
+a larger Python application is possible.
+
+Note that many functions are **not** given by formulae and this technique can't be applied.
+
+Symbolic differentiation was considered out of scope for ``scipy`` from previous discussions among devs and will not be further considered.
+
+####Automatic differentiation
+
+Automatic differentiation](http://en.wikipedia.org/wiki/Automatic_differentiation) is a technique to compute function derivatives in a very fast and precise way.
+
+It is very popular (see e.g.[Autodiff](http://www.autodiff.org/) or here [Julia](http://www.juliadiff.org),
+there's currently 10 Python packages implementing it listed [here](http://en.wikipedia.org/wiki/Automatic_differentiation#Software)
+
+The main drawbacks are that it doesn't work for all functions (only those that can be introspected
+and decomposed into steps on which the [chain rule](http://en.wikipedia.org/wiki/Chain_rule>)
+can be applied) and often requires the user to modify their function implementation.
+
+There were comments that automatic differentiation could be in scope for ``scipy.diff`` and e.g.
+the existing [algopy](https://github.com/b45ch1/algopy) and [ad](https://github.com/tisimst/ad) packages could be used as a basis.
+
+We do not consider automatic differentiation further here, but if possible would like to implement
+and API for ``scipy.diff`` that makes it possible to add it in the future as an extra method.
+
+####Finite differences
+
+The method we actually propose should be implemented in ``scipy.diff`` (see [here](http://en.wikipedia.org/wiki/Finite_difference) and [here](http://en.wikipedia.org/wiki/Numerical_differentiation#Finite_difference_formula).
+
+It's biggest advantage is that it is completely general. It works for any input function
+to be differentiated, the function is only evaluated at some points, it can be considered a black box.
+Also derivatives of various orders can be very easily computed simply by using [different coefficients](http://en.wikipedia.org/wiki/Finite_difference_coefficient)
+
+However the finite difference method is very imprecise because of
+[round-off error](http://en.wikipedia.org/wiki/Round-off_error) for small step sizes ``h``
+as explained and illustrated [here](http://en.wikipedia.org/wiki/Numerical_differentiation#Practical_considerations_using_floating_point_arithmetic)
+
+A variety of adaptive methods that systematically vary the step size ``h`` or extrapolate to ![equation](http://i.imgur.com/o8lOi89.png) have been developed, increasing the precision of the derivative estimate at the cost of more function evaluations.
+
+Another approach is to use the [complex step derivative approximation] (http://mdolab.engin.umich.edu/sites/default/files/Martins2003CSD.pdf) if the function is analytic and supports complex value inputs.
+
+![equation](http://i.imgur.com/DUsKsaN.png)
+
+The challenge is to identify the handful of methods that provide best stability and accuracy for a given cost
+(number of function evaluations), giving users suitable tools for all applications.
+
+###Overview of other packages
+
+TODO: is there a paper or book or webpage giving an overview?
+
+If no, we can briefly describe them here:
+
+
+See section 5.7 "Numerical Derivatives" (page 186) in "Numerical Recipes in C":
+http://apps.nrbook.com/c/index.html
+
+#### GNU Scientific Library
+
+* https://www.gnu.org/software/gsl/manual/html_node/Numerical-Differentiation.html
+* https://www.gnu.org/software/gsl/manual/html_node/Numerical-Differentiation-functions.html#Numerical-Differentiation-functions
+* https://github.com/ampl/gsl/blob/master/deriv/deriv.c
+* https://root.cern.ch/drupal/content/function-derivation
+
+####Statsmodels
+* https://github.com/statsmodels/statsmodels/blob/master/statsmodels/tools/numdiff.py
+* https://www.kent.ac.uk/smsas/personal/msr/webfiles/complexstep/deriv2.pdf
+
+####Numdifftools
+* https://github.com/pbrod/numdifftools/blob/master/numdifftools/core.py
+* https://github.com/pbrod/numdifftools/blob/master/numdifftools/nd_algopy.py
+
+####Julia
+* http://www.juliadiff.org/
+
+####Algopy
+* https://github.com/b45ch1/algopy
+
+####AD
+* https://github.com/tisimst/ad
+
+####R
+* http://cran.r-project.org/web/packages/numDeriv/
+
+####MATLAB
+* http://in.mathworks.com/help/matlab/numerical-integration-and-differentiation.html
+
+###Proposed API for ``scipy.diff``
+
+Analogy to scipy.integrate (which contains functions that take functions or points as input):
+http://docs.scipy.org/doc/scipy-dev/reference/integrate.html
+
+Examples:
+http://docs.scipy.org/doc/scipy-dev/reference/generated/scipy.integrate.quad.html
+http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
+
+The classes as in [nd_cstep.py](https://github.com/pbrod/numdifftools/blob/master/numdifftools/nd_cstep.py) can be
+
+     Derivative()
+       def __init__(f, h=None, method=’central’, full_output=False)
+       def __call__(self, x, *args, **kwds)
+
+     Gradient():
+       def __init__(f, h=None, method=’central’, full_output=False)
+       def __call__(self, x, *args, **kwds)
+
+     Jacobian():
+       def __init__(f, h=None, method=’central’, full_output=False)
+       def __call__(self, x, *args, **kwds)
+ 
+     Hessian():
+       def __init__(f, h=None, method=’central’, full_output=False)
+       def __call__(self, x, *args, **kwds)
+
+The classes in [core.py](https://github.com/pbrod/numdifftools/blob/master/numdifftools/core.py) have to be refactored into the following class structure, where the additional options like ``vectorizate=False`` to be removed to be made uniform with the rest of API structure.
+
+     NDerivative():
+       def __init__(f, n=1, h=None, method=’central’, full_output=False, **options)
+       def __call__(self, x, *args, **kwds)
+
+Where options could be
+
+       Options = dict(order=2, Romberg_terms=2)
+
+arguments
+
+     f  : callable function
+
+     x : ndarray values at which the derivative needs to be calculated
+
+     method : str method to be used to approximate the derivative - 'central', 'forward', 'backward', 'complex', 'richardson'
+
+     n : Integer from 1 to 4 (Default 1) defining derivative order. Only 1 for complex method
+
+     order : Integer from 1 to 4 (Default 2) defining order of basic method used. For 'central' methods, it must be from the set [2,4].
+  
+     Romberg_terms : number of terms used in Romberg extrapolation
+
+     args : tuple arguments for the function f
+
+     kwrds : dict Keyword arguments for function `f`.
+
+     full_output : bool Set to True to print error messages.
+
+return 
+
+     res : DiffResult
+
+     The differentiation result represented as a DiffResult object. Important attributes are:
+
+         x: ndarray solution array,
+
+         success : bool a flag indicating if the derivative was calculated successfully
+
+         message : str which describes the cause of the error, if occurred
+
+         number_of_func_eval : int number of function evaluations
+
+         abserr  : abserr_round + abserr_truncate : float absolute value of the roundoff and truncation errors, if applicable
+
+####TODO
+* whether the ``h=None`` default would mean best step-size found using by around ![equation](http://i.imgur.com/N9SK08f.png) where s depends on the method and derivative order or ``[StepGenerator](https://github.com/pbrod/numdifftools/blob/master/numdifftools/nd_cstep.py#L128)``, based on  epsilon algorithm by wynn.
+* Whether the *args and **kwds should be in ``__init__`` or ``__call__``, the preference by Perk was for it being in ``__call__`` makes these object compatible with ``scipy.optimize.minimize(fun, x0, args=(), method=None, jac=None, hess=None,…..)`` where the args are passed both to the function and jac/hess if they are supplied.
+* Are the input arguments for the ``__init__`` sufficient ?
+* What should we compute and return for ``full_output=True``, are the present output terms in ``DiffResult`` sufficient ?
+* Make and organize a pool of univariate scalar functions with known derivatives up to 4 which can be used for testing/performance purposes.
+ * https://github.com/b45ch1/algopy/blob/master/algopy/nthderiv/nthderiv.py
+ * https://github.com/b45ch1/algopy/blob/master/algopy/tests/test_nthderiv.py
+* Make and organize a pool of  functions with known gradient/Jacobian/hessian which can be used for testing/performance purposes. (Maybe something can be taken from statsmodels)
+ * https://github.com/statsmodels/statsmodels/blob/master/statsmodels/tools/tests/test_numdiff.py
+
+#### Classes v/s Functions
+
+Thanks to @Per Brodtkorb for this reasoning
+
+The class interface better than the functional one because you can pass the resulting object as function to other methods/functions and these functions/methods do not need to know what it does behind the scenes or what options are used. This simple use case is exemplified here:
+
+    g = lambda x: 1./x
+    dg = Derivative(g, **options)
+    my_plot(dg)
+    my_plot(g)
+
+In order to do this with a functional interface one could wrap it like this:
+
+    dg2  = lambda x: fprime(g, x, **options)
+    my_plot(dg2)
+
+
+If you like the one-liner that the function gives, you could call the Derivate class like this
+   
+    Derivate(g, **options)(x)
+
+Which is very similar to the functional way:
+
+    fprime(g, x, **options)
+
+###Proposed methods for ``scipy.diff``
+
+Statsmodels and Numdifftools vary in aspects of speed and accuracy, in terms of approaches followed as mentioned in [comment](https://github.com/scipy/scipy/pull/2835#issuecomment-52372036)
+
+
+####Adaptive step methods
+
+* Richardson extrapolation and Romberg terms
+* Tools to estimate optimal step size ``h``
+* What [numdifftools](https://github.com/statsmodels/statsmodels/blob/master/statsmodels/tools/numdiff.py) does
+* Numdifftools uses adaptive step-size to calculate finite differences, but will suffer from dilemma to choose small step-size to reduce truncation error but at the same time avoid subtractive cancellation at too small values.
+
+####Fixed complex step method
+
+* What's in [statsmodels](https://github.com/statsmodels/statsmodels/blob/master/statsmodels/tools/numdiff.py)
+* Central, forward, backward difference up to third derivative for O(h^2) and O(h^4) accuracy?
+* http://en.wikipedia.org/wiki/Finite_difference_coefficient
+* Statsmodels used complex step derivatives, which are for first order derivatives and have only truncation error, no roundoff error since there is no subtraction.
+* the complex-step method is only for first order derivatives and needs that function is analytic, so that Cauchy-Riemann equations are valid. So, is it possible to differentiate any function with this ?
+
+###Acknowledgements
+
+We would like to thank everyone that has given feedback on this document or ``scipy.diff`` in general
+via Github or scipy-dev or private email.
+
+* Alex Griffing (@argriffing)
+* Ralf Gommers (@rgommers)
+* Josef Perktold (@josef-pkt)
+* Per Brodtkorb (@pbrod)
+* Abraham Lee(@tisimst)
+* Sebastian Walter (@b45ch1)
+* Pauli Virtanen (@pv)
+
+-------------------------------------------------------------------------------
+
+###To be discussed / feedback needed
+
+This is a list of open questions that are being discussed.
+This sub-section will be removed soon.
+
+* Is the name ``scipy.diff`` the best choice, or would people prefer something else (e.g. ``scipy.derivative``)?
+  * It shouldn't be a problem later to take care of this
+
+* API: Handling broadcasting behavior along axes for input points  (R^n and array of points)?
+
+* Which methods?
+  * Complex step method?
+
+* API: Classes or Functions
+  * Functions as in scipy.optimize (minimize, root) is better, since it is coherent with API
+  * Discussed above in API
+
+* API: Functions as input / output or x / y values?
+  * Functions as input is the first priority
+
+* API: Return results object with access to full info?
+  * There will be cases where you want to return more info than (derivative estimate, derivative error estimate), e.g. number of function calls or even the function samples or a status code.
+  * It’s easy to attach useful extra info to the results object, and the extra cost for simple use cases of having to type `.value` to get at the derivative estimate is acceptable.
+
+* In scope? Parallel evaluation of function values to make use of multi-core? If yes, how (multiprocessing)?
+  * Though useful, preferably out of scope for now until any other feedback is possible
+
+* Automatic differentiation (AD) experts: is it possible to add AD methods to ``scipy.diff``
+  later with the current API? Is there a different API that would make it easier?
+  * still need feedback
+
+###References
+
+* DERIVEST, John, R. Errico [link](https://github.com/pbrod/numdifftools/blob/master/docs/DERIVEST.pdf)
+
+* The Complex-Step Derivative Approximation, JOAQUIM R. R. A. MARTINS [link](http://mdolab.engin.umich.edu/sites/default/files/Martins2003CSD.pdf)
+
+* Statistical Applications of the Complex-step Method of Numerical Differentiation, M. S. RIDOUT [link](https://www.kent.ac.uk/smsas/personal/msr/webfiles/complexstep/deriv2.pdf)
+
+* Numerical Methods Using Matlab, John H. Mathews and Kurtis K. Fink [link](mathfaculty.fullerton.edu/mathews/n2003/differentiation/numericaldiffproof.pdf)
+
+* Using Complex Variables to Estimate Derivatives of Real Functions, William Squire and George Trapp [link](http://www.jstor.org/stable/2653003)
+
+* Richardson Extrapolation and Romberg Integration [link](http://www.eng.utah.edu/~cs6210/lecture24.pdf)
+
+* NONLINEAR SEQUENCE TRANSFORMATIONS FOR THE ACCELERATION OF CONVERGENCE AND THE SUMMATION OF DIVERGENT SERIES [link](arxiv.org/pdf/math/0306302v1.pdf)

--- a/wiki/gsod/gsod-2022.md
+++ b/wiki/gsod/gsod-2022.md
@@ -1,0 +1,94 @@
+# Create and document user journey maps and personas for SciPy
+
+## About your organization
+
+SciPy is a collection of mathematical algorithms and convenience functions built on the NumPy extension of Python. It adds significant power to the interactive Python session by providing the user with high-level commands and classes for manipulating and visualizing data, which makes it accessible and productive for programmers from any background or experience level. SciPy provides algorithms for optimization, integration, interpolation, eigenvalue problems, algebraic equations, differential equations, statistics and many other classes of problems.
+
+## About your project
+
+### Your project’s problem
+
+Although now independent, SciPy and NumPy are tightly linked communities. Until some time ago, they shared one documentation and website, and there is considerable overlap between users and even contributors of both libraries.
+
+Both NumPy and SciPy have a huge user base, with people from many different backgrounds and experience levels. Both projects also have a large documentation body, with extensive coverage of technical details, architecture and design decisions. Although comprehensive, the size and depth of the documentation for both projects can be a challenge for new users and new contributors, because it may be difficult to rank pages by importance or  prioritize what is necessary from what is optional.
+
+This project aims to identify and document [user stories](https://en.wikipedia.org/wiki/User_story) and personas as well as [journey maps](https://en.wikipedia.org/wiki/User_journey) that represent a few common use cases for the NumPy and SciPy documentations, identify pain points and implement solutions to them with the help of both communities.
+
+### Your project’s scope
+
+SciPy serves many kinds of users: students new to programming or Python, educators, researchers, domain experts in one of the areas that the projects cover, data scientists, library developers, packagers, and more. Our goal is to provide ways to guide those users to the parts of the documentation most relevant to them.
+
+This project aims to:
+
+- Identify typical user personas per project, and audit the current documentation for the workflows these personas face and their overall user experience in both sets of documentation; 
+- Reorganize the documentation for both projects to make those workflows clearer;
+- Create minimum sets of documentation for these workflows;
+- Work with the community to create journey maps for these personas and identify pain points and problems in the current organization of the docs;
+- Suggest and implement changes to the documentation based on this research.
+
+Work that is out-of-scope for this project:
+
+- Creating tutorials for end-users.
+
+We would like to select one technical writing candidate for this project, anticipating that if NumPy is also accepted into the program the technical writers selected for both projects can collaborate as the projects are similar. We have two mentors who have committed to supporting the project.
+
+Although we anticipate some time will be spent on onboarding and learning the technical processes involved in working on our documentation, to be able to identify our users and the target audience for our documentation, some familiarity or previous experience with SciPy is best.
+
+Technical writers interested in this project should have:
+
+- [ ] Basic understanding of Sphinx for documentation
+- [ ] Understanding of the SciPy project scope
+- [ ] The willingness to attend community meetings
+- [ ] Basic knowledge of inclusive writing practices
+
+Two experienced mentors will be available to provide walkthroughs, set up time for discussing with or interviewing different kinds of end-users and content experts as needed. We are open to listening to writers' suggestions and contributions.
+
+### Measuring your project’s success
+
+The SciPy issue tracker shows a large number of documentation-related issues. Although it is possible that some of them will be solved in the course of this project, this is not our main focus. 
+
+We would consider the project successful if:
+
+- Five user personas are identified and documented for SciPy;
+    + Each persona should be fleshed out to reflect the diversity in our user base, and also to support a wide variety of backgrounds and experience levels. 
+- User journey maps are documented for each of the personas identified;
+  + Each user journey will involve segments of the documentation along with a rough time commitment
+  + Each user journey will consist of a guided tour of relevant sections of the documentation in response to common questions
+- A report with recommendations is created to guide the implementation of the changes suggested by this research.
+
+If there is time and the writer is interested, they can implement high-priority tasks identified in the first part of the work. 
+
+### Timeline
+
+We anticipate the project to be developed over six months, and we expect the technical writer to be able to dedicate around 20 hours per week for the project. This timeline includes the onboarding of the technical writer and reviewing existing literature on user journeys and how to effectively identify different use cases for the documentation.
+
+| Dates | Action Items |
+|-------|--------------|
+| May | Onboarding and literature review |
+|June - July | Audit existing documentation and identify user personas |
+| August - September | Identify user journey maps |
+| October | Write report and create recommendations for documentation improvement |
+| November | Project completion |
+
+## Project budget
+
+| Budget item | Amount | Running Total | Notes/justifications |
+|-------------|--------|---------------|----------------------|
+| Technical writer for SciPy | 15000.00 | 15000.00 |  |
+| TOTAL | | 15000.00 | |
+
+### Additional information
+
+SciPy has successfully participated in Google Season of Docs in 2019. The mentors for this project, Pamphile Roy and Melissa Mendonça, are members of the SciPy Community, with experience mentoring and creating documentation, as well as around the tooling and infrastructure involved in creating the documentation for SciPy.
+
+The SciPy maintainers drive and decide on documentation changes as they are proposed. We also welcome ideas around accessibility, usability and inclusion when creating documentation for SciPy. We have bi-weekly community meetings and also plan on working closely with the [NumPy documentation team](https://numpy.org/teams).
+
+Current documentation:
+
+- Latest version (tutorial, reference guide, developer docs): https://scipy.github.io/devdocs/index.html
+- Historical archive of released documentation: https://docs.scipy.org/doc/
+- SciPy website: http://www.scipy.org/
+- GitHub repository (all sources for code and docs): https://github.com/scipy/scipy
+
+
+Please visit https://scipy.org/contribute for contact information. You can also write directly to numpy-scipy-gsod@googlegroups.com with specific questions.

--- a/wiki/scipy-development-hangouts.md
+++ b/wiki/scipy-development-hangouts.md
@@ -1,0 +1,17 @@
+**Note: these hangouts have not happened (after the first one) - not enough bandwidth to schedule and call in, with people being busy and in almost every time zone in the world. We may get back to them in the future.**
+
+
+This page has details for, and links to meeting minutes of, video conferences about SciPy development topics. We aim to have these once every 6-8 weeks, starting Oct 2016.
+
+## 14 Oct 2016
+
+- Topic: writing (a) paper(s) on SciPy
+- Time: 7pm UTC
+- Link to connect: https://hangouts.google.com/call/3rb6vaez7bf63e6ih4qhxtsuaqe
+- Minutes: https://docs.google.com/document/d/1srVFUvxEUOKzJBuCI8oqn17D7TYLcLIwMJKFRRD4bB0/edit?usp=sharing
+- Participants: Evgeni Burovski, Josh Wilson, Eric Larson, Ralf Gommers, Andrew Nelson, Tyler Reddy
+
+Material relevant to the topic:
+- Adding DOIs for releases via Zenodo: https://github.com/scipy/scipy/issues/6446
+- Announcement of plan to write a paper on scipy-dev: https://mail.scipy.org/pipermail/scipy-dev/2016-August/021459.html
+- off list discussion by the core team


### PR DESCRIPTION
Here's my audit of the wiki, let me know what you think!

## Active (keep)

- [1.13.0 release notes](https://github.com/scipy/scipy/wiki/*Release-Note-Entries-for-SciPy-1.13.0-(asterisk-makes-this-appear-at-the-top))
- [CI dev best practices](https://github.com/scipy/scipy/wiki/Best-practice-for-development-of-CI-configurations)
- [SciPy 2.0 ideas](https://github.com/scipy/scipy/wiki/Ideas-for-changes-&-cleanups-in-SciPy-2.0)

## Unsure?

- [`scipy.signal` to-do list](https://github.com/scipy/scipy/wiki/scipy.signal-to-do-list) - clearly out of date but perhaps relevant stuff there?
- [Web service infrastructure](https://github.com/scipy/scipy/wiki/Web-service-infrastructure) - this should be replaced with up to date information, either on the wiki or elsewhere
- [Cython wrappers](https://github.com/scipy/scipy/wiki/Cython-Wrappers) - probably a bit out of date but still valuable info
- [Dropping support for accelerate](https://github.com/scipy/scipy/wiki/Dropping-support-for-Accelerate) - archive now that we are bringing accelerate back?
- [Reading `mat` files](https://github.com/scipy/scipy/wiki/Reading-mat-file-class-objects) - keep if still relevant?


## Archive (no longer relevant but historically valuable) - in this PR

- GSoC Project Ideas 2015-2019, 2021-2022
- GSoC 2014 Discrete Wavelet Transforms
- GSoC Rotation Formalism
- GSoD 2022
- GSoC `scipy.diff`
- SciPy development hangouts

## Delete (no longer relevant and no historical value)

- [Windows 10 build demo](https://github.com/scipy/scipy/wiki/Easy-Windows-10-Build-Scipy-from-source) - outdated (or archive?)
- [THANKS.txt 1.5.0](https://github.com/scipy/scipy/wiki/THANKS.txt-additions-modifications-for-1.5.0*)
- [THANKS.txt 1.6.0](https://github.com/scipy/scipy/wiki/THANKS.txt-additions-modifications-for-1.6.0*)
- [1.10.0 release notes](https://github.com/scipy/scipy/wiki/Release-Note-Entries-for-SciPy-1.10.0)
- [1.11.0 release notes](https://github.com/scipy/scipy/wiki/Release-Note-Entries-for-SciPy-1.11.0)
- [1.9.0 release notes](https://github.com/scipy/scipy/wiki/Release-note-entries-for-SciPy-1.9.0)
- [1.8.0 release notes](https://github.com/scipy/scipy/wiki/Release-note-entries-for-SciPy-1.8.0)
- [1.7.0 release notes](https://github.com/scipy/scipy/wiki/Release-note-entries-for-SciPy-1.7.0)
- [GSoD 2019](https://github.com/scipy/scipy/wiki/Google-Summer-of-Docs-2019)

---

We can then point to this archive from the wiki home page.